### PR TITLE
Formatter alignment (no pun intended!)

### DIFF
--- a/packages/foundry/.prettierrc
+++ b/packages/foundry/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "arrowParens": "avoid",
+  "printWidth": 120,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/packages/foundry/.prettierrc
+++ b/packages/foundry/.prettierrc
@@ -2,5 +2,6 @@
   "arrowParens": "avoid",
   "printWidth": 120,
   "tabWidth": 2,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "bracketSpacing": true
 }

--- a/packages/foundry/contracts/Spotlight.sol
+++ b/packages/foundry/contracts/Spotlight.sol
@@ -56,9 +56,7 @@ contract Spotlight {
 
   /// @notice Constructor sets the contract owner during deployment.
   /// @param _owner The address of the owner.
-  constructor(
-    address _owner
-  ) {
+  constructor(address _owner) {
     owner = _owner;
   }
 
@@ -70,9 +68,7 @@ contract Spotlight {
 
   /// @notice Modifier to ensure that a username meets the length requirements.
   /// @param _username The username to be validated.
-  modifier usernameValid(
-    string memory _username
-  ) {
+  modifier usernameValid(string memory _username) {
     require(bytes(_username).length > 0, "Username cannot be empty");
     require(bytes(_username).length < 32, "Username too long");
     _;
@@ -81,15 +77,11 @@ contract Spotlight {
   /// @notice Register a new profile with a unique username.
   /// @dev The username is checked for uniqueness after normalization (case-insensitive).
   /// @param _username The desired username for the profile.
-  function registerProfile(
-    string memory _username
-  ) public usernameValid(_username) {
+  function registerProfile(string memory _username) public usernameValid(_username) {
     require(!isRegistered(msg.sender), "Profile already exists");
 
     bytes32 usernameHash = _getUsernameHash(_username);
-    require(
-      !normalized_username_hashes[usernameHash], "Username is already taken"
-    );
+    require(!normalized_username_hashes[usernameHash], "Username is already taken");
 
     normalized_username_hashes[usernameHash] = true;
 
@@ -103,9 +95,7 @@ contract Spotlight {
   /// @notice Check if an address is registered with a profile.
   /// @param a The address to check.
   /// @return True if the address has a registered profile, false otherwise.
-  function isRegistered(
-    address a
-  ) public view returns (bool) {
+  function isRegistered(address a) public view returns (bool) {
     return bytes(profiles[a].username).length > 0;
   }
 
@@ -113,9 +103,7 @@ contract Spotlight {
   /// @dev The profile must exist for the specified address.
   /// @param a The address of the profile owner.
   /// @return The username associated with the address.
-  function getProfile(
-    address a
-  ) public view returns (string memory) {
+  function getProfile(address a) public view returns (string memory) {
     require(bytes(profiles[a].username).length > 0, "Profile does not exist");
     return profiles[a].username;
   }
@@ -123,9 +111,7 @@ contract Spotlight {
   /// @notice Update the username of the caller's profile.
   /// @dev The new username must be unique and meet length requirements.
   /// @param _newUsername The new username to set for the profile.
-  function updateUsername(
-    string memory _newUsername
-  ) public onlyRegistered usernameValid(_newUsername) {
+  function updateUsername(string memory _newUsername) public onlyRegistered usernameValid(_newUsername) {
     bytes32 newHash = _getUsernameHash(_newUsername);
     require(!normalized_username_hashes[newHash], "Username is already taken");
 
@@ -149,13 +135,12 @@ contract Spotlight {
     delete profiles[msg.sender];
     emit ProfileDeleted(msg.sender);
   }
+
   /// @dev Generate a hash from a normalized (lowercase) username.
   /// @param _username The original username.
   /// @return The keccak256 hash of the lowercase username.
 
-  function _getUsernameHash(
-    string memory _username
-  ) private pure returns (bytes32) {
+  function _getUsernameHash(string memory _username) private pure returns (bytes32) {
     string memory lowercaseUsername = _toLower(_username);
     return keccak256(abi.encodePacked(lowercaseUsername));
   }
@@ -163,9 +148,7 @@ contract Spotlight {
   /// @dev Convert a string to lowercase.
   /// @param _s The original string.
   /// @return The lowercase version of the input string.
-  function _toLower(
-    string memory _s
-  ) private pure returns (string memory) {
+  function _toLower(string memory _s) private pure returns (string memory) {
     bytes memory orig_s = bytes(_s);
     bytes memory new_s = new bytes(orig_s.length);
 
@@ -186,18 +169,12 @@ contract Spotlight {
   /// @notice Create a post from the caller's address.
   /// @param _content The content of the post.
   /// @param _sig The signature of the post.
-  function createPost(
-    bytes calldata _content,
-    bytes calldata _sig
-  ) public onlyRegistered {
+  function createPost(bytes calldata _content, bytes calldata _sig) public onlyRegistered {
     require(_content.length > 0, "Post content cannot be empty");
     bytes32 data_hash = MessageHashUtils.toEthSignedMessageHash(_content);
-    require(
-      SignatureChecker.isValidSignatureNow(msg.sender, data_hash, _sig),
-      "Invalid signature"
-    );
+    require(SignatureChecker.isValidSignatureNow(msg.sender, data_hash, _sig), "Invalid signature");
 
-    Post memory p = Post({ creator: msg.sender, id: _sig, content: _content });
+    Post memory p = Post({creator: msg.sender, id: _sig, content: _content});
     postStore[_sig] = p;
     communityPostIDs.push(_sig);
     profiles[msg.sender].postIDs.push(_sig);
@@ -206,9 +183,7 @@ contract Spotlight {
 
   /// @notice Get all posts for a given address
   /// @param _addr Wallet address of the registered user whose posts we wish to retrieve
-  function getPostsOfAddress(
-    address _addr
-  ) public view onlyRegistered returns (Post[] memory) {
+  function getPostsOfAddress(address _addr) public view onlyRegistered returns (Post[] memory) {
     // TODO: Add pagination - https://programtheblockchain.com/posts/2018/04/20/storage-patterns-pagination/
     require(isRegistered(_addr), "Requested address is not registered");
 
@@ -221,9 +196,7 @@ contract Spotlight {
     return userPosts;
   }
 
-  function getPost(
-    bytes calldata _post_sig
-  ) public view onlyRegistered returns (Post memory) {
+  function getPost(bytes calldata _post_sig) public view onlyRegistered returns (Post memory) {
     Post memory p = postStore[_post_sig];
     require(p.creator != address(0), "Requested post not found");
     return p;
@@ -231,12 +204,7 @@ contract Spotlight {
 
   // TODO: add community ID argument - what community are you trying to get posts for?
   /// @notice Get all posts from a community
-  function getCommunityPosts()
-    public
-    view
-    onlyRegistered
-    returns (Post[] memory)
-  {
+  function getCommunityPosts() public view onlyRegistered returns (Post[] memory) {
     // TODO: Add pagination - https://programtheblockchain.com/posts/2018/04/20/storage-patterns-pagination/
     Post[] memory p = new Post[](communityPostIDs.length);
     for (uint256 i = 0; i < communityPostIDs.length; i++) {

--- a/packages/foundry/contracts/Spotlight.sol
+++ b/packages/foundry/contracts/Spotlight.sol
@@ -174,7 +174,7 @@ contract Spotlight {
     bytes32 data_hash = MessageHashUtils.toEthSignedMessageHash(_content);
     require(SignatureChecker.isValidSignatureNow(msg.sender, data_hash, _sig), "Invalid signature");
 
-    Post memory p = Post({creator: msg.sender, id: _sig, content: _content});
+    Post memory p = Post({ creator: msg.sender, id: _sig, content: _content });
     postStore[_sig] = p;
     communityPostIDs.push(_sig);
     profiles[msg.sender].postIDs.push(_sig);

--- a/packages/foundry/contracts/YourContract.sol
+++ b/packages/foundry/contracts/YourContract.sol
@@ -68,12 +68,12 @@ contract YourContract {
    * The function can only be called by the owner of the contract as defined by the isOwner modifier
    */
   function withdraw() public isOwner {
-    (bool success,) = owner.call{value: address(this).balance}("");
+    (bool success,) = owner.call{ value: address(this).balance }("");
     require(success, "Failed to send Ether");
   }
 
   /**
    * Function that allows the contract to receive ETH
    */
-  receive() external payable {}
+  receive() external payable { }
 }

--- a/packages/foundry/contracts/YourContract.sol
+++ b/packages/foundry/contracts/YourContract.sol
@@ -21,18 +21,11 @@ contract YourContract {
   mapping(address => uint256) public userGreetingCounter;
 
   // Events: a way to emit log statements from smart contract that can be listened to by external parties
-  event GreetingChange(
-    address indexed greetingSetter,
-    string newGreeting,
-    bool premium,
-    uint256 value
-  );
+  event GreetingChange(address indexed greetingSetter, string newGreeting, bool premium, uint256 value);
 
   // Constructor: Called once on contract deployment
   // Check packages/foundry/deploy/Deploy.s.sol
-  constructor(
-    address _owner
-  ) {
+  constructor(address _owner) {
     owner = _owner;
   }
 
@@ -49,9 +42,7 @@ contract YourContract {
    *
    * @param _newGreeting (string memory) - new greeting to save on the contract
    */
-  function setGreeting(
-    string memory _newGreeting
-  ) public payable {
+  function setGreeting(string memory _newGreeting) public payable {
     // Print data to the anvil chain console. Remove when deploying to a live network.
 
     console.logString("Setting new greeting");
@@ -77,12 +68,12 @@ contract YourContract {
    * The function can only be called by the owner of the contract as defined by the isOwner modifier
    */
   function withdraw() public isOwner {
-    (bool success,) = owner.call{ value: address(this).balance }("");
+    (bool success,) = owner.call{value: address(this).balance}("");
     require(success, "Failed to send Ether");
   }
 
   /**
    * Function that allows the contract to receive ETH
    */
-  receive() external payable { }
+  receive() external payable {}
 }

--- a/packages/foundry/foundry.toml
+++ b/packages/foundry/foundry.toml
@@ -34,11 +34,11 @@ sepolia = { key = "${ETHERSCAN_API_KEY}" }
 
 
 [fmt]
-multiline_func_header = "params_first"
-line_length = 80
+#multiline_func_header = "params_first"
+line_length = 120
 tab_width = 2
 quote_style = "double"
-bracket_spacing = true
+# bracket_spacing = true
 int_types = "long"
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/packages/foundry/foundry.toml
+++ b/packages/foundry/foundry.toml
@@ -34,11 +34,10 @@ sepolia = { key = "${ETHERSCAN_API_KEY}" }
 
 
 [fmt]
-#multiline_func_header = "params_first"
 line_length = 120
 tab_width = 2
 quote_style = "double"
-# bracket_spacing = true
+bracket_spacing = true
 int_types = "long"
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/packages/foundry/script/Deploy.s.sol
+++ b/packages/foundry/script/Deploy.s.sol
@@ -18,9 +18,7 @@ contract DeployScript is ScaffoldETHDeploy {
     vm.startBroadcast(deployerPrivateKey);
 
     Spotlight spotlight = new Spotlight(vm.addr(deployerPrivateKey));
-    console.logString(
-      string.concat("Spotlight deployed at: ", vm.toString(address(spotlight)))
-    );
+    console.logString(string.concat("Spotlight deployed at: ", vm.toString(address(spotlight))));
 
     //YourContract yourContract = new YourContract(vm.addr(deployerPrivateKey));
     //console.logString(
@@ -39,5 +37,5 @@ contract DeployScript is ScaffoldETHDeploy {
     exportDeployments();
   }
 
-  function test() public { }
+  function test() public {}
 }

--- a/packages/foundry/script/Deploy.s.sol
+++ b/packages/foundry/script/Deploy.s.sol
@@ -37,5 +37,5 @@ contract DeployScript is ScaffoldETHDeploy {
     exportDeployments();
   }
 
-  function test() public {}
+  function test() public { }
 }

--- a/packages/foundry/script/DeployHelpers.s.sol
+++ b/packages/foundry/script/DeployHelpers.s.sol
@@ -41,9 +41,7 @@ contract ScaffoldETHDeploy is Script {
     uint256 len = deployments.length;
 
     for (uint256 i = 0; i < len; i++) {
-      vm.serializeString(
-        jsonWrite, vm.toString(deployments[i].addr), deployments[i].name
-      );
+      vm.serializeString(jsonWrite, vm.toString(deployments[i].addr), deployments[i].name);
     }
 
     string memory chainName;

--- a/packages/foundry/script/ListAccount.js
+++ b/packages/foundry/script/ListAccount.js
@@ -6,8 +6,7 @@ const QRCode = require("qrcode");
 const fs = require("fs");
 const toml = require("toml");
 
-const ALCHEMY_API_KEY =
-  process.env.ALCHEMY_API_KEY || "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF";
+const ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY || "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF";
 
 async function getBalanceForEachNetwork(address) {
   try {
@@ -27,8 +26,7 @@ async function getBalanceForEachNetwork(address) {
     }
 
     for (const networkName in rpcEndpoints) {
-      if (networkName === "localhost" || networkName === "default_network")
-        continue;
+      if (networkName === "localhost" || networkName === "default_network") continue;
 
       const networkUrl = replaceENVAlchemyKey(rpcEndpoints[networkName]);
 
@@ -37,10 +35,7 @@ async function getBalanceForEachNetwork(address) {
         const balance = await provider.getBalance(address);
         console.log("--", networkName, "-- 📡");
         console.log("   balance:", +ethers.utils.formatEther(balance));
-        console.log(
-          "   nonce:",
-          +(await provider.getTransactionCount(address))
-        );
+        console.log("   nonce:", +(await provider.getTransactionCount(address)));
       } catch (e) {
         console.log("Can't connect to network", networkName);
         console.log();
@@ -54,24 +49,20 @@ async function main() {
   const privateKey = process.env.DEPLOYER_PRIVATE_KEY;
 
   if (!privateKey) {
-    console.log(
-      "🚫️ You don't have a deployer account. Run `yarn generate` first"
-    );
+    console.log("🚫️ You don't have a deployer account. Run `yarn generate` first");
     return;
   }
 
   // Get account from private key.
   const wallet = new Wallet(privateKey);
   const address = wallet.address;
-  console.log(
-    await QRCode.toString(address, { type: "terminal", small: true })
-  );
+  console.log(await QRCode.toString(address, { type: "terminal", small: true }));
   console.log("Public address:", address, "\n");
 
   await getBalanceForEachNetwork(address);
 }
 
-main().catch((error) => {
+main().catch(error => {
   console.error(error);
   process.exitCode = 1;
 });

--- a/packages/foundry/script/VerifyAll.s.sol
+++ b/packages/foundry/script/VerifyAll.s.sol
@@ -17,9 +17,7 @@ struct FfiResult {
 }
 
 interface tempVm {
-  function tryFfi(
-    string[] calldata
-  ) external returns (FfiResult memory);
+  function tryFfi(string[] calldata) external returns (FfiResult memory);
 }
 
 contract VerifyAll is Script {
@@ -27,12 +25,7 @@ contract VerifyAll is Script {
 
   function run() external {
     string memory root = vm.projectRoot();
-    string memory path = string.concat(
-      root,
-      "/broadcast/Deploy.s.sol/",
-      vm.toString(block.chainid),
-      "/run-latest.json"
-    );
+    string memory path = string.concat(root, "/broadcast/Deploy.s.sol/", vm.toString(block.chainid), "/run-latest.json");
     string memory content = vm.readFile(path);
 
     while (this.nextTransaction(content)) {
@@ -41,42 +34,24 @@ contract VerifyAll is Script {
     }
   }
 
-  function _verifyIfContractDeployment(
-    string memory content
-  ) internal {
-    string memory txType = abi.decode(
-      vm.parseJson(content, searchStr(currTransactionIdx, "transactionType")),
-      (string)
-    );
+  function _verifyIfContractDeployment(string memory content) internal {
+    string memory txType = abi.decode(vm.parseJson(content, searchStr(currTransactionIdx, "transactionType")), (string));
     if (keccak256(bytes(txType)) == keccak256(bytes("CREATE"))) {
       _verifyContract(content);
     }
   }
 
-  function _verifyContract(
-    string memory content
-  ) internal {
-    string memory contractName = abi.decode(
-      vm.parseJson(content, searchStr(currTransactionIdx, "contractName")),
-      (string)
-    );
-    address contractAddr = abi.decode(
-      vm.parseJson(content, searchStr(currTransactionIdx, "contractAddress")),
-      (address)
-    );
-    bytes memory deployedBytecode = abi.decode(
-      vm.parseJson(content, searchStr(currTransactionIdx, "transaction.input")),
-      (bytes)
-    );
-    bytes memory compiledBytecode = abi.decode(
-      vm.parseJson(_getCompiledBytecode(contractName), ".bytecode.object"),
-      (bytes)
-    );
-    bytes memory constructorArgs = BytesLib.slice(
-      deployedBytecode,
-      compiledBytecode.length,
-      deployedBytecode.length - compiledBytecode.length
-    );
+  function _verifyContract(string memory content) internal {
+    string memory contractName =
+      abi.decode(vm.parseJson(content, searchStr(currTransactionIdx, "contractName")), (string));
+    address contractAddr =
+      abi.decode(vm.parseJson(content, searchStr(currTransactionIdx, "contractAddress")), (address));
+    bytes memory deployedBytecode =
+      abi.decode(vm.parseJson(content, searchStr(currTransactionIdx, "transaction.input")), (bytes));
+    bytes memory compiledBytecode =
+      abi.decode(vm.parseJson(_getCompiledBytecode(contractName), ".bytecode.object"), (bytes));
+    bytes memory constructorArgs =
+      BytesLib.slice(deployedBytecode, compiledBytecode.length, deployedBytecode.length - compiledBytecode.length);
 
     string[] memory inputs = new string[](9);
     inputs[0] = "forge";
@@ -92,11 +67,7 @@ contract VerifyAll is Script {
     FfiResult memory f = tempVm(address(vm)).tryFfi(inputs);
 
     if (f.stderr.length != 0) {
-      console.logString(
-        string.concat(
-          "Submitting verification for contract: ", vm.toString(contractAddr)
-        )
-      );
+      console.logString(string.concat("Submitting verification for contract: ", vm.toString(contractAddr)));
       console.logString(string(f.stderr));
     } else {
       console.logString(string(f.stdout));
@@ -104,9 +75,7 @@ contract VerifyAll is Script {
     return;
   }
 
-  function nextTransaction(
-    string memory content
-  ) external view returns (bool) {
+  function nextTransaction(string memory content) external view returns (bool) {
     try this.getTransactionFromRaw(content, currTransactionIdx) {
       return true;
     } catch {
@@ -114,26 +83,17 @@ contract VerifyAll is Script {
     }
   }
 
-  function _getCompiledBytecode(
-    string memory contractName
-  ) internal view returns (string memory compiledBytecode) {
+  function _getCompiledBytecode(string memory contractName) internal view returns (string memory compiledBytecode) {
     string memory root = vm.projectRoot();
-    string memory path =
-      string.concat(root, "/out/", contractName, ".sol/", contractName, ".json");
+    string memory path = string.concat(root, "/out/", contractName, ".sol/", contractName, ".json");
     compiledBytecode = vm.readFile(path);
   }
 
-  function getTransactionFromRaw(
-    string memory content,
-    uint96 idx
-  ) external pure {
+  function getTransactionFromRaw(string memory content, uint96 idx) external pure {
     abi.decode(vm.parseJson(content, searchStr(idx, "hash")), (bytes32));
   }
 
-  function searchStr(
-    uint96 idx,
-    string memory searchKey
-  ) internal pure returns (string memory) {
+  function searchStr(uint96 idx, string memory searchKey) internal pure returns (string memory) {
     return string.concat(".transactions[", vm.toString(idx), "].", searchKey);
   }
 }

--- a/packages/foundry/script/generateAccount.js
+++ b/packages/foundry/script/generateAccount.js
@@ -34,16 +34,14 @@ async function main() {
   // .env file exists
   const existingEnvConfig = parse(fs.readFileSync(envFilePath).toString());
   if (existingEnvConfig.DEPLOYER_PRIVATE_KEY) {
-    console.log(
-      "⚠️ You already have a deployer account. Check the packages/foundry/.env file"
-    );
+    console.log("⚠️ You already have a deployer account. Check the packages/foundry/.env file");
     return;
   }
 
   setNewEnvConfig(existingEnvConfig);
 }
 
-main().catch((error) => {
+main().catch(error => {
   console.error(error);
   process.exitCode = 1;
 });

--- a/packages/foundry/script/generateTsAbis.js
+++ b/packages/foundry/script/generateTsAbis.js
@@ -22,14 +22,8 @@ function getFiles(path) {
   });
 }
 function getArtifactOfContract(contractName) {
-  const current_path_to_artifacts = path.join(
-    __dirname,
-    "..",
-    `out/${contractName}.sol`
-  );
-  const artifactJson = JSON.parse(
-    fs.readFileSync(`${current_path_to_artifacts}/${contractName}.json`)
-  );
+  const current_path_to_artifacts = path.join(__dirname, "..", `out/${contractName}.sol`);
+  const artifactJson = JSON.parse(fs.readFileSync(`${current_path_to_artifacts}/${contractName}.json`));
 
   return artifactJson;
 }
@@ -40,9 +34,7 @@ function getInheritedFromContracts(artifact) {
     for (const astNode of artifact.ast.nodes) {
       if (astNode.nodeType == "ContractDefinition") {
         if (astNode.baseContracts.length > 0) {
-          inheritedFromContracts = astNode.baseContracts.map(
-            ({ baseName }) => baseName.name
-          );
+          inheritedFromContracts = astNode.baseContracts.map(({ baseName }) => baseName.name);
         }
       }
     }
@@ -68,11 +60,7 @@ function getInheritedFunctions(mainArtifact) {
 }
 
 function main() {
-  const current_path_to_broadcast = path.join(
-    __dirname,
-    "..",
-    "broadcast/Deploy.s.sol"
-  );
+  const current_path_to_broadcast = path.join(__dirname, "..", "broadcast/Deploy.s.sol");
   const current_path_to_deployments = path.join(__dirname, "..", "deployments");
 
   const chains = getDirectories(current_path_to_broadcast);
@@ -80,31 +68,24 @@ function main() {
 
   const deployments = {};
 
-  Deploymentchains.forEach((chain) => {
+  Deploymentchains.forEach(chain => {
     if (!chain.endsWith(".json")) return;
     chain = chain.slice(0, -5);
-    var deploymentObject = JSON.parse(
-      fs.readFileSync(`${current_path_to_deployments}/${chain}.json`)
-    );
+    var deploymentObject = JSON.parse(fs.readFileSync(`${current_path_to_deployments}/${chain}.json`));
     deployments[chain] = deploymentObject;
   });
 
   const allGeneratedContracts = {};
 
-  chains.forEach((chain) => {
+  chains.forEach(chain => {
     allGeneratedContracts[chain] = {};
-    const broadCastObject = JSON.parse(
-      fs.readFileSync(`${current_path_to_broadcast}/${chain}/run-latest.json`)
-    );
+    const broadCastObject = JSON.parse(fs.readFileSync(`${current_path_to_broadcast}/${chain}/run-latest.json`));
     const transactionsCreate = broadCastObject.transactions.filter(
-      (transaction) => transaction.transactionType == "CREATE"
+      transaction => transaction.transactionType == "CREATE",
     );
-    transactionsCreate.forEach((transaction) => {
+    transactionsCreate.forEach(transaction => {
       const artifact = getArtifactOfContract(transaction.contractName);
-      allGeneratedContracts[chain][
-        deployments[chain][transaction.contractAddress] ||
-          transaction.contractName
-      ] = {
+      allGeneratedContracts[chain][deployments[chain][transaction.contractAddress] || transaction.contractName] = {
         address: transaction.contractAddress,
         abi: artifact.abi,
         inheritedFunctions: getInheritedFunctions(artifact),
@@ -114,16 +95,9 @@ function main() {
 
   const TARGET_DIR = "../nextjs/contracts/";
 
-  const fileContent = Object.entries(allGeneratedContracts).reduce(
-    (content, [chainId, chainConfig]) => {
-      return `${content}${parseInt(chainId).toFixed(0)}:${JSON.stringify(
-        chainConfig,
-        null,
-        2
-      )},`;
-    },
-    ""
-  );
+  const fileContent = Object.entries(allGeneratedContracts).reduce((content, [chainId, chainConfig]) => {
+    return `${content}${parseInt(chainId).toFixed(0)}:${JSON.stringify(chainConfig, null, 2)},`;
+  }, "");
 
   if (!fs.existsSync(TARGET_DIR)) {
     fs.mkdirSync(TARGET_DIR);
@@ -135,8 +109,8 @@ function main() {
  const deployedContracts = {${fileContent}} as const; \n\n export default deployedContracts satisfies GenericContractsDeclaration`,
       {
         parser: "typescript",
-      }
-    )
+      },
+    ),
   );
 }
 

--- a/packages/foundry/test/Posts.t.sol
+++ b/packages/foundry/test/Posts.t.sol
@@ -17,10 +17,7 @@ contract PostManagementTest is Test {
     wallet = vm.createWallet(1);
   }
 
-  function signContentViaWallet(
-    Vm.Wallet memory _w,
-    string memory _content
-  ) internal returns (bytes memory) {
+  function signContentViaWallet(Vm.Wallet memory _w, string memory _content) internal returns (bytes memory) {
     bytes32 digest = MessageHashUtils.toEthSignedMessageHash(bytes(_content));
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(_w, digest);
     bytes memory signature = abi.encodePacked(r, s, v);
@@ -42,9 +39,7 @@ contract PostManagementTest is Test {
     spotlight.createPost("Hello, world!", signature);
   }
 
-  function testSignatureThatCannotBeVerifiedResultsInRevertingPostCreation()
-    public
-  {
+  function testSignatureThatCannotBeVerifiedResultsInRevertingPostCreation() public {
     vm.startPrank(wallet.addr);
     spotlight.registerProfile("username");
 
@@ -67,8 +62,7 @@ contract PostManagementTest is Test {
     spotlight.createPost("2", signContentViaWallet(wallet, "2"));
     spotlight.createPost("3", signContentViaWallet(wallet, "3"));
 
-    Spotlight.Post memory p =
-      spotlight.getPost(signContentViaWallet(wallet, "2"));
+    Spotlight.Post memory p = spotlight.getPost(signContentViaWallet(wallet, "2"));
     assertEq("2", string(p.content));
     assertEq(wallet.addr, p.creator);
     assertEq(signContentViaWallet(wallet, "2"), p.id);

--- a/packages/foundry/test/YourContract.t.sol
+++ b/packages/foundry/test/YourContract.t.sol
@@ -12,17 +12,11 @@ contract YourContractTest is Test {
   }
 
   function testMessageOnDeployment() public view {
-    require(
-      keccak256(bytes(yourContract.greeting()))
-        == keccak256("Building Unstoppable Apps!!!")
-    );
+    require(keccak256(bytes(yourContract.greeting())) == keccak256("Building Unstoppable Apps!!!"));
   }
 
   function testSetNewMessage() public {
     yourContract.setGreeting("Learn Scaffold-ETH 2! :)");
-    require(
-      keccak256(bytes(yourContract.greeting()))
-        == keccak256("Learn Scaffold-ETH 2! :)")
-    );
+    require(keccak256(bytes(yourContract.greeting())) == keccak256("Learn Scaffold-ETH 2! :)"));
   }
 }


### PR DESCRIPTION
VSCode generally uses prettier which has one formatting style defined in `.prettierrc`, while the `forge fmt` command leverages what `foundry.toml` defines...but they don't match!

This attempts to resolve their discrepancies so if you're using VSCode, prettier will produce something `forge fmt` likes and vice versa

Oddly enough, scaffold-eth provides a `prettier.json` but that wasn't being used by VSCode - because it needs to be `.prettierc` so that file was also added

The `.sol` file changes are just from the updated formatting configuration(s)