### PR TITLE
Add more entropy into post signature to ensure uniqueness

### DIFF
--- a/packages/foundry/contracts/PostLib.sol
+++ b/packages/foundry/contracts/PostLib.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+
+import "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+library PostLib {
+  // TODO: Decouple the Post structure from it's signature primitives by creating a SignedPost struct
+  /// @notice Structure to store the reference to a post
+  struct Post {
+    address creator;
+    bytes id;
+    string content;
+    string title;
+    uint256 createdAt;
+    uint256 lastUpdatedAt;
+  }
+  // TODO: Add a community pointer
+  // TODO: Add likes
+  // TODO: Add comments
+  /* NICE TO HAVE: 
+      If we want to get fancy, we can ensure uniqueness by requiring post creation to include a nonce that is equal to 
+      exactly 1 + userProfile.postNonce
+  */
+
+  function abiEncodePost(Post memory _p) internal pure returns (bytes memory) {
+    // Include everything EXCEPT `id` which is the signature itself and `creator`
+    return abi.encodePacked(_p.title, _p.content, _p.createdAt, _p.lastUpdatedAt);
+  }
+
+  function isValidPostSignature(address _addr, Post memory _p, bytes memory _sig) internal view returns (bool) {
+    bytes32 data_hash = MessageHashUtils.toEthSignedMessageHash(abiEncodePost(_p));
+    return SignatureChecker.isValidSignatureNow(_addr, data_hash, _sig);
+  }
+}

--- a/packages/foundry/test/Posts.t.sol
+++ b/packages/foundry/test/Posts.t.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
 
 import "forge-std/Test.sol";
 import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 
 import "../contracts/Spotlight.sol";
 import "../contracts/Events.sol";
+import "../contracts/PostLib.sol";
 
 contract PostManagementTest is Test {
   Spotlight public spotlight;
@@ -17,26 +18,43 @@ contract PostManagementTest is Test {
     wallet = vm.createWallet(1);
   }
 
-  function signContentViaWallet(Vm.Wallet memory _w, string memory _content) internal returns (bytes memory) {
-    bytes32 digest = MessageHashUtils.toEthSignedMessageHash(bytes(_content));
-    (uint8 v, bytes32 r, bytes32 s) = vm.sign(_w, digest);
+  function createTestPost() internal pure returns (PostLib.Post memory) {
+    PostLib.Post memory p;
+    p.content = "Hello, world!";
+    p.title = "Title";
+    p.createdAt = 123;
+    p.lastUpdatedAt = 123;
+    return p;
+  }
+
+  function createTestPost(string memory content) internal pure returns (PostLib.Post memory) {
+    PostLib.Post memory p = createTestPost();
+    p.content = content;
+    return p;
+  }
+
+  function signContentViaWallet(Vm.Wallet memory _w, PostLib.Post memory _p) internal returns (bytes memory) {
+    bytes32 data_hash = MessageHashUtils.toEthSignedMessageHash(PostLib.abiEncodePost(_p));
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(_w, data_hash);
     bytes memory signature = abi.encodePacked(r, s, v);
     return signature;
   }
 
   function testCannotCreatePostIfAddressNotRegistered() public {
     vm.expectRevert("Profile does not exist");
-    spotlight.createPost("Hello, world!", "not a sig");
+    spotlight.createPost(createTestPost(), "not a sig");
   }
 
   function testRegisteredAddressCanCreatePostAndEmitsAPostCreatedEvent() public {
     vm.startPrank(wallet.addr);
     spotlight.registerProfile("Username");
 
+    PostLib.Post memory post = createTestPost();
+    bytes memory signature = signContentViaWallet(wallet, post);
+
     vm.expectEmit();
-    bytes memory signature = signContentViaWallet(wallet, "Hello, world!");
     emit PostCreated(wallet.addr, signature);
-    spotlight.createPost("Hello, world!", signature);
+    spotlight.createPost(post, signature);
   }
 
   function testSignatureThatCannotBeVerifiedResultsInRevertingPostCreation() public {
@@ -44,28 +62,63 @@ contract PostManagementTest is Test {
     spotlight.registerProfile("username");
 
     vm.expectRevert("Invalid signature");
-    spotlight.createPost("Hello, world!", "Fake signature");
+    spotlight.createPost(createTestPost(), "Fake signature");
   }
 
-  function testEmptyPostIsRejected() public {
+  function testCreatePostWithEmptyContentIsRejected() public {
     vm.startPrank(wallet.addr);
     spotlight.registerProfile("username");
 
-    vm.expectRevert("Post content cannot be empty");
-    spotlight.createPost("", "Sig won't be checked here");
+    PostLib.Post memory p = createTestPost();
+    p.content = "";
+    vm.expectRevert("Content cannot be empty");
+    spotlight.createPost(p, "Sig won't be checked here");
+  }
+
+  function testCreatePostWithEmptyTitleIsRejected() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
+
+    PostLib.Post memory p = createTestPost();
+    p.title = "";
+    vm.expectRevert("Title cannot be empty");
+    spotlight.createPost(p, "Sig won't be checked here");
+  }
+
+  function testCreatePostWithMissingCreatedTimestampIsRejected() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
+
+    PostLib.Post memory p = createTestPost();
+    p.createdAt = 0;
+    vm.expectRevert("Created timestamp is missing");
+    spotlight.createPost(p, "Sig won't be checked here");
+  }
+
+  function testCreatePostWithMissingLastUpdatedTimestampIsRejected() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
+
+    PostLib.Post memory p = createTestPost();
+    p.lastUpdatedAt = 0;
+    vm.expectRevert("Last updated timestamp is missing");
+    spotlight.createPost(p, "Sig won't be checked here");
   }
 
   function testPostCanBeRetrievedBySignature() public {
     vm.startPrank(wallet.addr);
+    PostLib.Post memory p1 = createTestPost("1");
+    PostLib.Post memory p2 = createTestPost("2");
+    PostLib.Post memory p3 = createTestPost("3");
     spotlight.registerProfile("username");
-    spotlight.createPost("1", signContentViaWallet(wallet, "1"));
-    spotlight.createPost("2", signContentViaWallet(wallet, "2"));
-    spotlight.createPost("3", signContentViaWallet(wallet, "3"));
+    spotlight.createPost(p1, signContentViaWallet(wallet, p1));
+    spotlight.createPost(p2, signContentViaWallet(wallet, p2));
+    spotlight.createPost(p3, signContentViaWallet(wallet, p3));
 
-    Spotlight.Post memory p = spotlight.getPost(signContentViaWallet(wallet, "2"));
-    assertEq("2", string(p.content));
-    assertEq(wallet.addr, p.creator);
-    assertEq(signContentViaWallet(wallet, "2"), p.id);
+    PostLib.Post memory retreivedP2 = spotlight.getPost(signContentViaWallet(wallet, p2));
+    assertEq("2", string(retreivedP2.content));
+    assertEq(wallet.addr, retreivedP2.creator);
+    assertEq(signContentViaWallet(wallet, p2), retreivedP2.id);
   }
 
   function testGettingNonexistentPostReverts() public {
@@ -78,18 +131,22 @@ contract PostManagementTest is Test {
 
   function testUserCanGetListOfSpecificUserPosts() public {
     Vm.Wallet memory _w = vm.createWallet(100);
+    PostLib.Post memory _wPost = createTestPost("_w");
     vm.startPrank(_w.addr);
     spotlight.registerProfile("_w");
-    spotlight.createPost("_w", signContentViaWallet(_w, "_w"));
+    spotlight.createPost(_wPost, signContentViaWallet(_w, _wPost));
     vm.stopPrank();
 
+    PostLib.Post memory p0 = createTestPost("0");
+    PostLib.Post memory p1 = createTestPost("1");
+    PostLib.Post memory p2 = createTestPost("2");
     vm.startPrank(wallet.addr);
     spotlight.registerProfile("username");
-    spotlight.createPost("0", signContentViaWallet(wallet, "0"));
-    spotlight.createPost("1", signContentViaWallet(wallet, "1"));
-    spotlight.createPost("2", signContentViaWallet(wallet, "2"));
+    spotlight.createPost(p0, signContentViaWallet(wallet, p0));
+    spotlight.createPost(p1, signContentViaWallet(wallet, p1));
+    spotlight.createPost(p2, signContentViaWallet(wallet, p2));
 
-    Spotlight.Post[] memory posts = spotlight.getPostsOfAddress(wallet.addr);
+    PostLib.Post[] memory posts = spotlight.getPostsOfAddress(wallet.addr);
     assertEq(3, posts.length);
 
     // NOTE: These assertions will need to be updated when we start "sorting" by latest posts
@@ -101,16 +158,18 @@ contract PostManagementTest is Test {
     assertEq("1", string(posts[1].content));
     assertEq("2", string(posts[2].content));
 
-    assertEq(signContentViaWallet(wallet, "0"), posts[0].id);
-    assertEq(signContentViaWallet(wallet, "1"), posts[1].id);
-    assertEq(signContentViaWallet(wallet, "2"), posts[2].id);
+    assertEq(signContentViaWallet(wallet, p0), posts[0].id);
+    assertEq(signContentViaWallet(wallet, p1), posts[1].id);
+    assertEq(signContentViaWallet(wallet, p2), posts[2].id);
 
     // We can also get the post of the first user, right?
     posts = spotlight.getPostsOfAddress(_w.addr);
     assertEq(1, posts.length);
     assertEq(_w.addr, posts[0].creator);
-    assertEq(bytes("_w"), posts[0].content);
-    assertEq(signContentViaWallet(_w, "_w"), posts[0].id);
+    assertEq("_w", posts[0].content);
+    assertEq(signContentViaWallet(_w, _wPost), posts[0].id);
+
+    assertTrue(PostLib.isValidPostSignature(_w.addr, posts[0], posts[0].id));
   }
 
   function testUserCanGetListOfAllPostsInCommunity() public {
@@ -118,40 +177,43 @@ contract PostManagementTest is Test {
     Vm.Wallet[] memory wallets = new Vm.Wallet[](3);
 
     // NOTE: Cannot create a wallet @ address 0
+    PostLib.Post memory p0 = createTestPost("0");
     wallets[0] = vm.createWallet(10);
     vm.startPrank(wallets[0].addr);
     spotlight.registerProfile("0");
-    spotlight.createPost(bytes("0"), signContentViaWallet(wallets[0], "0"));
+    spotlight.createPost(p0, signContentViaWallet(wallets[0], p0));
     vm.stopPrank();
 
+    PostLib.Post memory p1 = createTestPost("1");
     wallets[1] = vm.createWallet(11);
     vm.startPrank(wallets[1].addr);
     spotlight.registerProfile("1");
-    spotlight.createPost(bytes("1"), signContentViaWallet(wallets[1], "1"));
+    spotlight.createPost(p1, signContentViaWallet(wallets[1], p1));
     vm.stopPrank();
 
+    PostLib.Post memory p2 = createTestPost("2");
     wallets[2] = vm.createWallet(12);
     vm.startPrank(wallets[2].addr);
     spotlight.registerProfile("2");
-    spotlight.createPost(bytes("2"), signContentViaWallet(wallets[2], "2"));
+    spotlight.createPost(p2, signContentViaWallet(wallets[2], p2));
     vm.stopPrank();
 
     // We're expecting 3 posts to be returned
     vm.startPrank(wallets[0].addr);
-    Spotlight.Post[] memory posts = spotlight.getCommunityPosts();
+    PostLib.Post[] memory posts = spotlight.getCommunityPosts();
     assertEq(3, posts.length);
 
     assertEq(wallets[0].addr, posts[0].creator);
     assertEq(wallets[1].addr, posts[1].creator);
     assertEq(wallets[2].addr, posts[2].creator);
 
-    assertEq(signContentViaWallet(wallets[0], "0"), posts[0].id);
-    assertEq(signContentViaWallet(wallets[1], "1"), posts[1].id);
-    assertEq(signContentViaWallet(wallets[2], "2"), posts[2].id);
+    assertEq(signContentViaWallet(wallets[0], p0), posts[0].id);
+    assertEq(signContentViaWallet(wallets[1], p1), posts[1].id);
+    assertEq(signContentViaWallet(wallets[2], p2), posts[2].id);
 
-    assertEq(bytes("0"), posts[0].content);
-    assertEq(bytes("1"), posts[1].content);
-    assertEq(bytes("2"), posts[2].content);
+    assertEq("0", posts[0].content);
+    assertEq("1", posts[1].content);
+    assertEq("2", posts[2].content);
   }
 
   function testGettingPostsOfUnregisteredUserReverts() public {
@@ -164,9 +226,10 @@ contract PostManagementTest is Test {
   }
 
   function testUnregisteredUserCannotGetPostsOfAnotherUser() public {
+    PostLib.Post memory p = createTestPost();
     vm.startPrank(wallet.addr);
     spotlight.registerProfile("username");
-    spotlight.createPost("post", signContentViaWallet(wallet, "post"));
+    spotlight.createPost(p, signContentViaWallet(wallet, p));
     vm.stopPrank();
 
     address _addr = vm.addr(2);
@@ -176,9 +239,10 @@ contract PostManagementTest is Test {
   }
 
   function testUnregisteredUserCannotSeePostsOfACommunity() public {
+    PostLib.Post memory p = createTestPost();
     vm.startPrank(wallet.addr);
     spotlight.registerProfile("username");
-    spotlight.createPost("post", signContentViaWallet(wallet, "post"));
+    spotlight.createPost(p, signContentViaWallet(wallet, p));
     vm.stopPrank();
 
     address _addr = vm.addr(2);


### PR DESCRIPTION
Per our discussion yesterday, post signatures are now created with
* the title
* the content
* the created timestamp
* the last updated timestamp

There's an implication here to call out: when you create, the nextJS must also pass in the lastUpdatedAt field.

This simply provides an air of completeness, that is to say: anything the dApp submitted has been signed...you cannot tamper with ANY of the post fields.

### Extra
In an attempt to experiment with "separation of concerns" - I moved some Post related utilities and the `Post` struct definition into it's own library that Spotlight uses.