### PR TITLE
Introduce paywalled content in a backwards compatible manner

### DIFF
--- a/packages/foundry/contracts/PostLib.sol
+++ b/packages/foundry/contracts/PostLib.sol
@@ -13,6 +13,7 @@ library PostLib {
     string content;
     bytes id;
     bytes signature;
+    bool paywalled;
     uint256 nonce;
     uint256 createdAt;
     uint256 lastUpdatedAt;

--- a/packages/foundry/contracts/Spotlight.sol
+++ b/packages/foundry/contracts/Spotlight.sol
@@ -201,10 +201,13 @@ contract Spotlight {
   /// @param _content The content of the post.
   /// @param _nonce The nonce used for signature generation
   /// @param _sig The signature of the post.
-  function createPost(string memory _title, string memory _content, uint256 _nonce, bytes calldata _sig)
-    public
-    onlyRegistered
-  {
+  function createPost(
+    string memory _title,
+    string memory _content,
+    uint256 _nonce,
+    bytes calldata _sig,
+    bool _paywalled
+  ) public onlyRegistered {
     if (bytes(_content).length == 0) revert ContentCannotBeEmpty();
     if (bytes(_title).length == 0) revert TitleCannotBeEmpty();
     if (!PostLib.isValidPostSignature(msg.sender, _title, _content, _nonce, _sig)) revert InvalidSignature();
@@ -218,6 +221,7 @@ contract Spotlight {
       id: _sig,
       signature: _sig,
       nonce: _nonce,
+      paywalled: _paywalled,
       createdAt: block.timestamp,
       lastUpdatedAt: block.timestamp,
       upvoteCount: 0,

--- a/packages/foundry/test/Posts.t.sol
+++ b/packages/foundry/test/Posts.t.sol
@@ -43,7 +43,7 @@ contract PostManagementTest is Test {
   function testCannotCreatePostIfAddressNotRegistered() public {
     vm.expectRevert(ProfileNotExist.selector);
     PostLib.Post memory p = createTestPost();
-    spotlight.createPost(p.title, p.content, p.nonce, "not a sig");
+    spotlight.createPost(p.title, p.content, p.nonce, "not a sig", false);
   }
 
   function testRegisteredAddressCanCreatePostAndEmitsAPostCreatedEvent() public {
@@ -55,7 +55,7 @@ contract PostManagementTest is Test {
 
     vm.expectEmit();
     emit PostCreated(wallet.addr, signature);
-    spotlight.createPost(post.title, post.content, post.nonce, signature);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, false);
   }
 
   function testSignatureThatCannotBeVerifiedResultsInRevertingPostCreation() public {
@@ -64,7 +64,7 @@ contract PostManagementTest is Test {
 
     vm.expectRevert(InvalidSignature.selector);
     PostLib.Post memory p = createTestPost();
-    spotlight.createPost(p.title, p.content, p.nonce, "Fake signature");
+    spotlight.createPost(p.title, p.content, p.nonce, "Fake signature", false);
   }
 
   function testCreatePostWithEmptyContentIsRejected() public {
@@ -74,7 +74,7 @@ contract PostManagementTest is Test {
     PostLib.Post memory p = createTestPost();
     p.content = "";
     vm.expectRevert(ContentCannotBeEmpty.selector);
-    spotlight.createPost(p.title, p.content, p.nonce, "Sig won't be checked here");
+    spotlight.createPost(p.title, p.content, p.nonce, "Sig won't be checked here", false);
   }
 
   function testCreatePostWithEmptyTitleIsRejected() public {
@@ -84,7 +84,7 @@ contract PostManagementTest is Test {
     PostLib.Post memory p = createTestPost();
     p.title = "";
     vm.expectRevert(TitleCannotBeEmpty.selector);
-    spotlight.createPost(p.title, p.content, p.nonce, "Sig won't be checked here");
+    spotlight.createPost(p.title, p.content, p.nonce, "Sig won't be checked here", false);
   }
 
   function testPostCanBeRetrievedBySignature() public {
@@ -93,14 +93,15 @@ contract PostManagementTest is Test {
     PostLib.Post memory p2 = createTestPost("2");
     PostLib.Post memory p3 = createTestPost("3");
     spotlight.registerProfile("username");
-    spotlight.createPost(p1.title, p1.content, p1.nonce, signContentViaWallet(wallet, p1));
-    spotlight.createPost(p2.title, p2.content, p2.nonce, signContentViaWallet(wallet, p2));
-    spotlight.createPost(p3.title, p3.content, p3.nonce, signContentViaWallet(wallet, p3));
+    spotlight.createPost(p1.title, p1.content, p1.nonce, signContentViaWallet(wallet, p1), false);
+    spotlight.createPost(p2.title, p2.content, p2.nonce, signContentViaWallet(wallet, p2), false);
+    spotlight.createPost(p3.title, p3.content, p3.nonce, signContentViaWallet(wallet, p3), false);
 
     PostLib.Post memory retreivedP2 = spotlight.getPost(signContentViaWallet(wallet, p2));
     assertEq("2", string(retreivedP2.content));
     assertEq(wallet.addr, retreivedP2.creator);
     assertEq(signContentViaWallet(wallet, p2), retreivedP2.id);
+    assertFalse(retreivedP2.paywalled);
   }
 
   function testGettingNonexistentPostReverts() public {
@@ -116,7 +117,7 @@ contract PostManagementTest is Test {
     PostLib.Post memory _wPost = createTestPost("_w");
     vm.startPrank(_w.addr);
     spotlight.registerProfile("_w");
-    spotlight.createPost(_wPost.title, _wPost.content, _wPost.nonce, signContentViaWallet(_w, _wPost));
+    spotlight.createPost(_wPost.title, _wPost.content, _wPost.nonce, signContentViaWallet(_w, _wPost), false);
     vm.stopPrank();
 
     PostLib.Post memory p0 = createTestPost("0");
@@ -124,9 +125,9 @@ contract PostManagementTest is Test {
     PostLib.Post memory p2 = createTestPost("2");
     vm.startPrank(wallet.addr);
     spotlight.registerProfile("username");
-    spotlight.createPost(p0.title, p0.content, p0.nonce, signContentViaWallet(wallet, p0));
-    spotlight.createPost(p1.title, p1.content, p1.nonce, signContentViaWallet(wallet, p1));
-    spotlight.createPost(p2.title, p2.content, p2.nonce, signContentViaWallet(wallet, p2));
+    spotlight.createPost(p0.title, p0.content, p0.nonce, signContentViaWallet(wallet, p0), false);
+    spotlight.createPost(p1.title, p1.content, p1.nonce, signContentViaWallet(wallet, p1), false);
+    spotlight.createPost(p2.title, p2.content, p2.nonce, signContentViaWallet(wallet, p2), false);
 
     PostLib.Post[] memory posts = spotlight.getPostsOfAddress(wallet.addr);
     assertEq(3, posts.length);
@@ -163,21 +164,21 @@ contract PostManagementTest is Test {
     wallets[0] = vm.createWallet(10);
     vm.startPrank(wallets[0].addr);
     spotlight.registerProfile("0");
-    spotlight.createPost(p0.title, p0.content, p0.nonce, signContentViaWallet(wallets[0], p0));
+    spotlight.createPost(p0.title, p0.content, p0.nonce, signContentViaWallet(wallets[0], p0), false);
     vm.stopPrank();
 
     PostLib.Post memory p1 = createTestPost("1");
     wallets[1] = vm.createWallet(11);
     vm.startPrank(wallets[1].addr);
     spotlight.registerProfile("1");
-    spotlight.createPost(p1.title, p1.content, p1.nonce, signContentViaWallet(wallets[1], p1));
+    spotlight.createPost(p1.title, p1.content, p1.nonce, signContentViaWallet(wallets[1], p1), false);
     vm.stopPrank();
 
     PostLib.Post memory p2 = createTestPost("2");
     wallets[2] = vm.createWallet(12);
     vm.startPrank(wallets[2].addr);
     spotlight.registerProfile("2");
-    spotlight.createPost(p2.title, p2.content, p2.nonce, signContentViaWallet(wallets[2], p2));
+    spotlight.createPost(p2.title, p2.content, p2.nonce, signContentViaWallet(wallets[2], p2), false);
     vm.stopPrank();
 
     // We're expecting 3 posts to be returned
@@ -211,7 +212,7 @@ contract PostManagementTest is Test {
     PostLib.Post memory p = createTestPost();
     vm.startPrank(wallet.addr);
     spotlight.registerProfile("username");
-    spotlight.createPost(p.title, p.content, p.nonce, signContentViaWallet(wallet, p));
+    spotlight.createPost(p.title, p.content, p.nonce, signContentViaWallet(wallet, p), false);
     vm.stopPrank();
 
     address _addr = vm.addr(2);
@@ -224,7 +225,7 @@ contract PostManagementTest is Test {
     PostLib.Post memory p = createTestPost();
     vm.startPrank(wallet.addr);
     spotlight.registerProfile("username");
-    spotlight.createPost(p.title, p.content, p.nonce, signContentViaWallet(wallet, p));
+    spotlight.createPost(p.title, p.content, p.nonce, signContentViaWallet(wallet, p), false);
     vm.stopPrank();
 
     address _addr = vm.addr(2);
@@ -239,7 +240,7 @@ contract PostManagementTest is Test {
 
     PostLib.Post memory post = createTestPost();
     bytes memory signature = signContentViaWallet(wallet, post);
-    spotlight.createPost(post.title, post.content, post.nonce, signature);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, false);
 
     vm.expectEmit();
     emit PostEdited(wallet.addr, signature);
@@ -257,7 +258,7 @@ contract PostManagementTest is Test {
 
     PostLib.Post memory post = createTestPost();
     bytes memory signature = signContentViaWallet(wallet, post);
-    spotlight.createPost(post.title, post.content, post.nonce, signature);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, false);
     vm.stopPrank();
 
     address otherUser = vm.addr(2);
@@ -274,7 +275,7 @@ contract PostManagementTest is Test {
 
     PostLib.Post memory post = createTestPost();
     bytes memory signature = signContentViaWallet(wallet, post);
-    spotlight.createPost(post.title, post.content, post.nonce, signature);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, false);
 
     vm.expectRevert(ContentCannotBeEmpty.selector);
     spotlight.editPost(signature, "");
@@ -287,7 +288,7 @@ contract PostManagementTest is Test {
 
     PostLib.Post memory post = createTestPost();
     bytes memory signature = signContentViaWallet(wallet, post);
-    spotlight.createPost(post.title, post.content, post.nonce, signature);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, false);
 
     vm.expectEmit();
     emit PostDeleted(wallet.addr, signature);
@@ -304,7 +305,7 @@ contract PostManagementTest is Test {
 
     PostLib.Post memory post = createTestPost();
     bytes memory signature = signContentViaWallet(wallet, post);
-    spotlight.createPost(post.title, post.content, post.nonce, signature);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, false);
     vm.stopPrank();
 
     address otherUser = vm.addr(2);
@@ -322,7 +323,7 @@ contract PostManagementTest is Test {
 
     PostLib.Post memory post = createTestPost();
     bytes memory signature = signContentViaWallet(wallet, post);
-    spotlight.createPost(post.title, post.content, post.nonce, signature);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, false);
     vm.stopPrank();
 
     address otherUser = vm.addr(2);
@@ -348,7 +349,7 @@ contract PostManagementTest is Test {
 
     PostLib.Post memory post = createTestPost();
     bytes memory signature = signContentViaWallet(wallet, post);
-    spotlight.createPost(post.title, post.content, post.nonce, signature);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, false);
 
     // Add multiple comments
     spotlight.addComment(signature, "First comment.");

--- a/packages/foundry/test/Votes.t.sol
+++ b/packages/foundry/test/Votes.t.sol
@@ -30,7 +30,7 @@ contract VotesTest is Test {
 
     vm.startPrank(wallet1.addr);
     spotlight.registerProfile("username");
-    spotlight.createPost(post.title, post.content, post.nonce, postSig);
+    spotlight.createPost(post.title, post.content, post.nonce, postSig, false);
     vm.stopPrank();
   }
 

--- a/packages/nextjs/app/debug/_components/contract/DisplayVariable.tsx
+++ b/packages/nextjs/app/debug/_components/contract/DisplayVariable.tsx
@@ -5,7 +5,7 @@ import { InheritanceTooltip } from "./InheritanceTooltip";
 import { displayTxResult } from "./utilsDisplay";
 import { Abi, AbiFunction } from "abitype";
 import { Address } from "viem";
-import { useReadContract } from "wagmi";
+import { useAccount, useReadContract } from "wagmi";
 import { ArrowPathIcon } from "@heroicons/react/24/outline";
 import { useAnimationConfig } from "~~/hooks/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
@@ -27,6 +27,7 @@ export const DisplayVariable = ({
   inheritedFrom,
 }: DisplayVariableProps) => {
   const { targetNetwork } = useTargetNetwork();
+  const { address: userAddress } = useAccount();
 
   const {
     data: result,
@@ -34,6 +35,7 @@ export const DisplayVariable = ({
     refetch,
     error,
   } = useReadContract({
+    account: userAddress,
     address: contractAddress,
     functionName: abiFunction.name,
     abi: abi,

--- a/packages/nextjs/app/feed/context.tsx
+++ b/packages/nextjs/app/feed/context.tsx
@@ -2,7 +2,7 @@ import { createContext } from "react";
 
 type EditorContextType = {
   setContent: (content: string) => void;
-  confirmPost: () => void;
+  confirmPost: (evt: React.MouseEventHandler<HTMLButtonElement>, paywalled: boolean) => void;
 };
 const EditorContext = createContext<EditorContextType | undefined>(undefined);
 

--- a/packages/nextjs/app/feed/createPost.tsx
+++ b/packages/nextjs/app/feed/createPost.tsx
@@ -4,8 +4,9 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { EditorContext } from "./context";
 import Editor from "./richTextEditor/Editor";
-import { encrypt } from "@metamask/eth-sig-util";
+import { decrypt, encrypt } from "@metamask/eth-sig-util";
 import { NextPage } from "next";
+import { toHex } from "viem";
 import { useAccount, useSignMessage } from "wagmi";
 import { useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 import { createPostSignature } from "~~/utils/spotlight";
@@ -14,7 +15,6 @@ const CreatePage: NextPage = () => {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const [clickPost, setClickPost] = useState(false);
-  const [paywalled, setPaywalled] = useState(false);
   const [postSig, setPostSig] = useState("");
   const router = useRouter();
   const { address } = useAccount();
@@ -33,38 +33,48 @@ const CreatePage: NextPage = () => {
     }
   }, [clickPost, router, postSig]);
 
+  const confirmPost = async (paywalled = false) => {
+    if (!address) {
+      return;
+    }
+    console.log("confirmPost.paywalled", paywalled);
+    if (paywalled) {
+      // TODO: The check for paywalling is buried in the editor right now. Make that a more global context
+      const publicKey = await window.ethereum.request({
+        method: "eth_getEncryptionPublicKey",
+        params: [address.toLowerCase()],
+      });
+      console.log("pubKey for encryption:", publicKey);
+      const encryptedPost = encrypt({ publicKey, data: content, version: "x25519-xsalsa20-poly1305" });
+      console.log(encryptedPost);
+      console.log(toHex(encryptedPost.ciphertext));
+
+      // sleep for 500ms - metamask gets unhappy if you hammer it with back-2-back reqs
+      await new Promise(f => setTimeout(f, 500));
+      const x = await window.ethereum.request({
+        method: "eth_decrypt",
+        params: [`0x${Buffer.from(JSON.stringify(encryptedPost), "utf8").toString("hex")}`, address],
+      });
+      console.log(x);
+    }
+    try {
+      // const nonce = BigInt(Math.ceil(Math.random() * 10 ** 17));
+      // const postSig = await createPostSignature({ signMessageAsync, title, content, nonce });
+      // setPostSig(postSig);
+      // console.log("Signature of post:", postSig);
+      // await writeSpotlightContractAsync({ functionName: "createPost", args: [title, content, nonce, postSig] });
+      // setClickPost(true);
+    } catch (e: any) {
+      console.log(e);
+    }
+  };
+
   const value = {
     setContent,
-    setPaywalled,
-    confirmPost: async () => {
-      if (!address) {
-        return;
-      }
-      // when confirmPost is called - this still appears to be "false"
-      console.log("confirmPost.paywalled", paywalled);
-      if (paywalled) {
-        // TODO: The check for paywalling is buried in the editor right now. Make that a more global context
-        const publicKey = await window.ethereum.request({
-          method: "eth_getEncryptionPublicKey",
-          params: [address.toLowerCase()],
-        });
-        console.log("pubKey for encryption:", publicKey);
-        const encryptedPost = encrypt({ publicKey, data: content, version: "x25519-xsalsa20-poly1305" });
-        console.log(encryptedPost);
-      }
-      try {
-        const nonce = BigInt(Math.ceil(Math.random() * 10 ** 17));
-        const postSig = await createPostSignature({ signMessageAsync, title, content, nonce });
-        setPostSig(postSig);
-
-        console.log("Signature of post:", postSig);
-
-        await writeSpotlightContractAsync({ functionName: "createPost", args: [title, content, nonce, postSig] });
-        setClickPost(true);
-      } catch (e: any) {
-        console.log(e);
-      }
+    confirmPaywallPost: async () => {
+      confirmPost(true);
     },
+    confirmPost,
   };
 
   return (

--- a/packages/nextjs/app/feed/richTextEditor/Editor.js
+++ b/packages/nextjs/app/feed/richTextEditor/Editor.js
@@ -22,7 +22,7 @@ import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPl
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
 import { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
-import { useAccount } from "wagmi";
+import { PaywallSupportContext } from "~~/contexts/PaywallSupport";
 
 function Placeholder() {
   return <div className="editor-placeholder">Enter some rich text...</div>;
@@ -53,32 +53,7 @@ const editorConfig = {
 
 export default function Editor() {
   const { confirmPost, confirmPaywallPost } = useContext(EditorContext);
-  const [showPaywallOption, setShowPaywallOption] = useState(false);
-  const { address } = useAccount();
-
-  useEffect(() => {
-    const checkIfEncryptionSupported = async () => {
-      try {
-        const ethAccounts = await window.ethereum.request({
-          "method": "eth_accounts",
-          "params": [],
-        });
-
-        // This checks if the metamask account is ACTUALLY the account being used in Spotlight
-        // (i.e. you can have MetaMask installed, but you're using a burner wallet/ledger/etc)
-        // We need to normalize the account addresses to make sure we can compare them
-        if (ethAccounts?.length > 0 && ethAccounts[0].toLowerCase() == address?.toLowerCase()) {
-          setShowPaywallOption(true);
-        } else {
-          setShowPaywallOption(false);
-        }
-      } catch {
-        setShowPaywallOption(false);
-      }
-    };
-
-    checkIfEncryptionSupported().catch((err) => console.log(err));
-  }, [address, window.ethereum, setShowPaywallOption])
+  const { paywallSupported } = useContext(PaywallSupportContext);
 
   return (
     <LexicalComposer initialConfig={editorConfig}>
@@ -101,13 +76,15 @@ export default function Editor() {
           <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
         </div>
         <div className="flex justify-end pt-2">
-          <button className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]" onClick={confirmPost}>
+          <button className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]" onClick={async(e) => confirmPost(e, false) }>
             Post
           </button>
-          {showPaywallOption && 
-            <button className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]" onClick={confirmPaywallPost}>
+          {paywallSupported && 
+          <div className="pl-2">
+            <button className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]" onClick={async(e) => confirmPost(e, true)}>
               Paywall Post
             </button>
+            </div>
           }
         </div>
       </div>

--- a/packages/nextjs/app/feed/richTextEditor/Editor.js
+++ b/packages/nextjs/app/feed/richTextEditor/Editor.js
@@ -82,7 +82,7 @@ export default function Editor() {
           >
             Post
           </button>
-          {paywallSupported &&
+          {paywallSupported && (
             <div className="pl-2">
               <button
                 className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]"
@@ -91,7 +91,7 @@ export default function Editor() {
                 Paywall Post
               </button>
             </div>
-          }
+          )}
         </div>
       </div>
     </LexicalComposer>

--- a/packages/nextjs/app/feed/richTextEditor/Editor.js
+++ b/packages/nextjs/app/feed/richTextEditor/Editor.js
@@ -76,12 +76,18 @@ export default function Editor() {
           <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
         </div>
         <div className="flex justify-end pt-2">
-          <button className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]" onClick={async e => confirmPost(e, false) }>
+          <button
+            className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]"
+            onClick={async e => confirmPost(e, false)}
+          >
             Post
           </button>
           {paywallSupported &&
             <div className="pl-2">
-              <button className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]" onClick={async e => confirmPost(e, true)}>
+              <button
+                className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]"
+                onClick={async e => confirmPost(e, true)}
+              >
                 Paywall Post
               </button>
             </div>

--- a/packages/nextjs/app/feed/richTextEditor/Editor.js
+++ b/packages/nextjs/app/feed/richTextEditor/Editor.js
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react";
+import { useContext } from "react";
 import { EditorContext } from "../context";
 import "../richTextEditor/styles.css";
 import AutoLinkPlugin from "./plugins/AutoLinkPlugin";
@@ -52,7 +52,7 @@ const editorConfig = {
 };
 
 export default function Editor() {
-  const { confirmPost, confirmPaywallPost } = useContext(EditorContext);
+  const { confirmPost } = useContext(EditorContext);
   const { paywallSupported } = useContext(PaywallSupportContext);
 
   return (
@@ -76,14 +76,14 @@ export default function Editor() {
           <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
         </div>
         <div className="flex justify-end pt-2">
-          <button className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]" onClick={async(e) => confirmPost(e, false) }>
+          <button className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]" onClick={async e => confirmPost(e, false) }>
             Post
           </button>
-          {paywallSupported && 
-          <div className="pl-2">
-            <button className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]" onClick={async(e) => confirmPost(e, true)}>
-              Paywall Post
-            </button>
+          {paywallSupported &&
+            <div className="pl-2">
+              <button className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]" onClick={async e => confirmPost(e, true)}>
+                Paywall Post
+              </button>
             </div>
           }
         </div>

--- a/packages/nextjs/app/feed/richTextEditor/Editor.js
+++ b/packages/nextjs/app/feed/richTextEditor/Editor.js
@@ -52,21 +52,27 @@ const editorConfig = {
 };
 
 export default function Editor() {
-  const { confirmPost, setPaywalled } = useContext(EditorContext);
+  const { confirmPost, confirmPaywallPost } = useContext(EditorContext);
   const [showPaywallOption, setShowPaywallOption] = useState(false);
   const { address } = useAccount();
 
   useEffect(() => {
     const checkIfEncryptionSupported = async () => {
-      const ethAccounts = await window.ethereum.request({
-        "method": "eth_accounts",
-        "params": [],
-      });
+      try {
+        const ethAccounts = await window.ethereum.request({
+          "method": "eth_accounts",
+          "params": [],
+        });
 
-      // We need to normalize the account addresses to make sure we can compare them
-      if (ethAccounts?.length > 0 && ethAccounts[0].toLowerCase() == address?.toLowerCase()) {
-        setShowPaywallOption(true);
-      } else {
+        // This checks if the metamask account is ACTUALLY the account being used in Spotlight
+        // (i.e. you can have MetaMask installed, but you're using a burner wallet/ledger/etc)
+        // We need to normalize the account addresses to make sure we can compare them
+        if (ethAccounts?.length > 0 && ethAccounts[0].toLowerCase() == address?.toLowerCase()) {
+          setShowPaywallOption(true);
+        } else {
+          setShowPaywallOption(false);
+        }
+      } catch {
         setShowPaywallOption(false);
       }
     };
@@ -99,11 +105,7 @@ export default function Editor() {
             Post
           </button>
           {showPaywallOption && 
-            <button className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]" onClick={async () => {
-              console.log("Editor.setPaywalled(true)");
-              setPaywalled(true);
-              confirmPost();
-            }}>
+            <button className="btn btn-outline rounded text-[#3466f6] border border-[#3466f6]" onClick={confirmPaywallPost}>
               Paywall Post
             </button>
           }

--- a/packages/nextjs/app/home/profile.tsx
+++ b/packages/nextjs/app/home/profile.tsx
@@ -117,7 +117,7 @@ function LeftColumn() {
       <div className="flex w-[100%] flex-col pl-4">
         <h1 className="text-left text-2xl font-bold text-gray-800">{userProfile.username}</h1>
         <div>Address: {shortenedUserAddress}</div>
-        <div>Reputation: {Number(userProfile.reputation)} RPT</div>
+        <div>Reputation: {Number(userProfile.reputation) / 10 ** 18} RPT</div>
       </div>
       <div className="flex flex-col justify-start items-center flex-grow-0 flex-shrink-0 sm:mt-4 mb-4">
         {deleted ? (
@@ -147,7 +147,7 @@ function LeftColumn() {
               </div>
             ) : (
               <>
-                <div className="flex space-x-4 mt-4 pb-5">
+                <div className="flex space-x-4 mt-4 pb-5 z-20">
                   <button className="btn btn-secondary" onClick={() => setIsChangingUsername(true)}>
                     Change Username
                   </button>

--- a/packages/nextjs/components/post/EditModal.tsx
+++ b/packages/nextjs/components/post/EditModal.tsx
@@ -19,6 +19,11 @@ const PostEditModal = ({ post }: { post: TPost }) => {
     watch: true,
   });
 
+  if (post.paywalled) {
+    // TODO: Think about support for editing paywalled post...
+    return <></>;
+  }
+
   const value = {
     setContent,
     cancel: () => {

--- a/packages/nextjs/components/post/Header.tsx
+++ b/packages/nextjs/components/post/Header.tsx
@@ -37,9 +37,12 @@ const PostHeader = ({ post }: { post: TPost }) => {
       <div className="flex gap-2">
         {address === post.creator && showPostMgmt && (
           <>
-            <button className="btn btn-danger btn-sm" onClick={e => onClickEditPost(e)} disabled={editing}>
-              <Image alt="Edit Post" className="cursor-pointer" width="20" height="25" src="/pencil.svg" />
-            </button>
+            {/* TODO: Think about support for editing paywalled post... */}
+            {!post.paywalled && (
+              <button className="btn btn-danger btn-sm" onClick={e => onClickEditPost(e)} disabled={editing}>
+                <Image alt="Edit Post" className="cursor-pointer" width="20" height="25" src="/pencil.svg" />
+              </button>
+            )}
             <button className="btn btn-danger btn-sm" onClick={e => onClickDeletePost(e)} disabled={deleting}>
               <Image alt="Delete Post" className="cursor-pointer" width="20" height="25" src="/trash.svg" />
             </button>

--- a/packages/nextjs/components/post/Post.tsx
+++ b/packages/nextjs/components/post/Post.tsx
@@ -38,7 +38,7 @@ const Post = ({ postId }: { postId: Hex }) => {
       {onProfile ? (
         <div className="cursor-pointer flex flex-col w-full">
           <p className="w-[100%] text-lg font-bold text-left text-black">{post.title}</p>
-          {post.paywalled ? TEMP_PAYWALL_MSG : <Viewer data={post.content} />}{" "}
+          {post.paywalled ? TEMP_PAYWALL_MSG : <Viewer data={post.content} />}
         </div>
       ) : compactDisplay ? (
         <div className="cursor-pointer flex flex-col w-full p-4 gap-4">
@@ -50,7 +50,7 @@ const Post = ({ postId }: { postId: Hex }) => {
           <div className="p-[10px]">
             <p className="text-2xl font-bold">{post.title}</p>
           </div>
-          {post.paywalled ? TEMP_PAYWALL_MSG : <Viewer data={post.content} />}{" "}
+          {post.paywalled ? TEMP_PAYWALL_MSG : <Viewer data={post.content} />}
         </>
       )}
 

--- a/packages/nextjs/components/post/Post.tsx
+++ b/packages/nextjs/components/post/Post.tsx
@@ -24,6 +24,9 @@ const Post = ({ postId }: { postId: Hex }) => {
     return;
   }
 
+  const trimId = post.id.substring(0, 6) + "..." + post.id.substring(post.id.length - 4);
+  const TEMP_PAYWALL_MSG = `${trimId} is paywalled - support coming soon`;
+
   return (
     <>
       {!onProfile && (
@@ -35,19 +38,19 @@ const Post = ({ postId }: { postId: Hex }) => {
       {onProfile ? (
         <div className="cursor-pointer flex flex-col w-full">
           <p className="w-[100%] text-lg font-bold text-left text-black">{post.title}</p>
-          <Viewer data={post.content} />
+          {post.paywalled ? TEMP_PAYWALL_MSG : <Viewer data={post.content} />}{" "}
         </div>
       ) : compactDisplay ? (
         <div className="cursor-pointer flex flex-col w-full p-4 gap-4">
           <p className="w-[100%] text-lg font-bold text-left text-black">{post.title}</p>
-          <Viewer data={post.content} />
+          {post.paywalled ? TEMP_PAYWALL_MSG : <Viewer data={post.content} />}
         </div>
       ) : (
         <>
           <div className="p-[10px]">
             <p className="text-2xl font-bold">{post.title}</p>
           </div>
-          <Viewer data={post.content} />
+          {post.paywalled ? TEMP_PAYWALL_MSG : <Viewer data={post.content} />}{" "}
         </>
       )}
 

--- a/packages/nextjs/contexts/PaywallSupport.tsx
+++ b/packages/nextjs/contexts/PaywallSupport.tsx
@@ -1,0 +1,13 @@
+import { createContext } from "react";
+
+interface IPaywallSupportContext {
+  paywallSupported: boolean;
+  setPaywallSupported: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const PaywallSupportContext = createContext<IPaywallSupportContext>({
+  paywallSupported: false,
+  setPaywallSupported: () => {
+    return false;
+  },
+});

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -7,7 +7,7 @@ import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 const deployedContracts = {
   31337: {
     Spotlight: {
-      address: "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0",
+      address: "0x5fbdb2315678afecb367f032d93f642f64180aa3",
       abi: [
         {
           type: "constructor",

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -7,7 +7,7 @@ import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 const deployedContracts = {
   31337: {
     Spotlight: {
-      address: "0x5fbdb2315678afecb367f032d93f642f64180aa3",
+      address: "0xa513e6e4b8f2a923d98304ec87f64353c4d5c853",
       abi: [
         {
           type: "constructor",
@@ -61,6 +61,11 @@ const deployedContracts = {
               name: "_sig",
               type: "bytes",
               internalType: "bytes",
+            },
+            {
+              name: "_paywalled",
+              type: "bool",
+              internalType: "bool",
             },
           ],
           outputs: [],
@@ -213,6 +218,11 @@ const deployedContracts = {
                   internalType: "bytes",
                 },
                 {
+                  name: "paywalled",
+                  type: "bool",
+                  internalType: "bool",
+                },
+                {
                   name: "nonce",
                   type: "uint256",
                   internalType: "uint256",
@@ -284,6 +294,11 @@ const deployedContracts = {
                   internalType: "bytes",
                 },
                 {
+                  name: "paywalled",
+                  type: "bool",
+                  internalType: "bool",
+                },
+                {
                   name: "nonce",
                   type: "uint256",
                   internalType: "uint256",
@@ -353,6 +368,11 @@ const deployedContracts = {
                   name: "signature",
                   type: "bytes",
                   internalType: "bytes",
+                },
+                {
+                  name: "paywalled",
+                  type: "bool",
+                  internalType: "bool",
                 },
                 {
                   name: "nonce",
@@ -826,6 +846,11 @@ const deployedContracts = {
               type: "bytes",
               internalType: "bytes",
             },
+            {
+              name: "_paywalled",
+              type: "bool",
+              internalType: "bool",
+            },
           ],
           outputs: [],
           stateMutability: "nonpayable",
@@ -977,6 +1002,11 @@ const deployedContracts = {
                   internalType: "bytes",
                 },
                 {
+                  name: "paywalled",
+                  type: "bool",
+                  internalType: "bool",
+                },
+                {
                   name: "nonce",
                   type: "uint256",
                   internalType: "uint256",
@@ -1048,6 +1078,11 @@ const deployedContracts = {
                   internalType: "bytes",
                 },
                 {
+                  name: "paywalled",
+                  type: "bool",
+                  internalType: "bool",
+                },
+                {
                   name: "nonce",
                   type: "uint256",
                   internalType: "uint256",
@@ -1117,6 +1152,11 @@ const deployedContracts = {
                   name: "signature",
                   type: "bytes",
                   internalType: "bytes",
+                },
+                {
+                  name: "paywalled",
+                  type: "bool",
+                  internalType: "bool",
                 },
                 {
                   name: "nonce",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@heroicons/react": "~2.0.11",
+    "@metamask/eth-sig-util": "^8.0.0",
     "@rainbow-me/rainbowkit": "2.1.5",
     "@tanstack/react-query": "~5.28.6",
     "@uniswap/sdk-core": "~4.0.1",

--- a/packages/nextjs/types/spotlight.ts
+++ b/packages/nextjs/types/spotlight.ts
@@ -9,6 +9,7 @@ export interface TPost {
   title: string;
   content: string;
   nonce: bigint;
+  paywalled: boolean;
   createdAt: bigint;
   lastUpdatedAt: bigint;
   upvoteCount: bigint;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1273,6 +1273,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/abi-utils@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@metamask/abi-utils@npm:2.0.4"
+  dependencies:
+    "@metamask/superstruct": ^3.1.0
+    "@metamask/utils": ^9.0.0
+  checksum: 85b15419248ddec1ab59ec5f3e41276f7509dadd9ced871658fa3cc04805ad35ace96986416aaecd24e3630e92b0ed078328966c92383ffa9b1cc3f0f357ad6c
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-json-rpc-provider@npm:^1.0.0":
   version: 1.0.1
   resolution: "@metamask/eth-json-rpc-provider@npm:1.0.1"
@@ -1281,6 +1291,20 @@ __metadata:
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^5.0.1
   checksum: ff97648b002d2889bd020c03abc26137cf068df3280e46144b5333c1b294f35f5099361343825f900ef20b9dcb6819495830b7a99eb1cbfbd671e5b11c0dfde1
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-sig-util@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@metamask/eth-sig-util@npm:8.0.0"
+  dependencies:
+    "@ethereumjs/util": ^8.1.0
+    "@metamask/abi-utils": ^2.0.4
+    "@metamask/utils": ^9.0.0
+    "@scure/base": ~1.1.3
+    ethereum-cryptography: ^2.1.2
+    tweetnacl: ^1.0.3
+  checksum: ce78cb8e65211b907a010bcc4f0ee6775f42db1eed4c9cf3385e430123382a70b7d0ff53fd53577ea4dba7c7ac31e0b47fa1f2079613e1d75e89d7089693f4d4
   languageName: node
   linkType: hard
 
@@ -2142,7 +2166,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@scure/base@npm:^1.1.3, @scure/base@npm:~1.1.0, @scure/base@npm:~1.1.2, @scure/base@npm:~1.1.6, @scure/base@npm:~1.1.7, @scure/base@npm:~1.1.8":
+"@scure/base@npm:^1.1.3, @scure/base@npm:~1.1.0, @scure/base@npm:~1.1.2, @scure/base@npm:~1.1.3, @scure/base@npm:~1.1.6, @scure/base@npm:~1.1.7, @scure/base@npm:~1.1.8":
   version: 1.1.9
   resolution: "@scure/base@npm:1.1.9"
   checksum: 120820a37dfe9dfe4cab2b7b7460552d08e67dee8057ed5354eb68d8e3440890ae983ce3bee957d2b45684950b454a2b6d71d5ee77c1fd3fddc022e2a510337f
@@ -2232,6 +2256,7 @@ __metadata:
   resolution: "@se-2/nextjs@workspace:packages/nextjs"
   dependencies:
     "@heroicons/react": ~2.0.11
+    "@metamask/eth-sig-util": ^8.0.0
     "@rainbow-me/rainbowkit": 2.1.5
     "@tanstack/react-query": ~5.28.6
     "@trivago/prettier-plugin-sort-imports": ~4.1.1
@@ -6378,7 +6403,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethereum-cryptography@npm:^2.0.0":
+"ethereum-cryptography@npm:^2.0.0, ethereum-cryptography@npm:^2.1.2":
   version: 2.2.1
   resolution: "ethereum-cryptography@npm:2.2.1"
   dependencies:
@@ -11704,6 +11729,13 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 1843f4c1b2e0f975e08c4c21caa4af4f7f65a12ac1b81b3b8489366826259323feb3fc7a243123453d2d1a02314205a7634e048d4a8009921da19f99755cdc48
+  languageName: node
+  linkType: hard
+
+"tweetnacl@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "tweetnacl@npm:1.0.3"
+  checksum: e4a57cac188f0c53f24c7a33279e223618a2bfb5fea426231991652a13247bea06b081fd745d71291fcae0f4428d29beba1b984b1f1ce6f66b06a6d1ab90645c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Update contract Post struct to track new boolean property: `paywalled`
* UI detects if you can use encrypt/decrypt Metamaske wallet methods
* If not - app works identically as before
* If supported
  * User can create posts with `paywalled` field set to true
  * Editor content is encrypted using Metamask wallet method `eth_encrypt`
* Post rendering:
  * If post is paywalled, show generic "coming soon" message
  * If post is paywalled, disallow editing
  * Creator can still delete post