### PR TITLE
Paywall feature - user can now pay for a paywalled post

### DIFF
--- a/packages/foundry/contracts/Error.sol
+++ b/packages/foundry/contracts/Error.sol
@@ -37,3 +37,7 @@ error OnlySpotlightContractCanIssueTokens();
 error OnlySpotlightContractCanBurnTokens();
 
 error AvatarCIDCannotBeEmpty();
+
+error InsufficentPostFunds();
+
+error PostAlreadyPurchased();

--- a/packages/foundry/contracts/Error.sol
+++ b/packages/foundry/contracts/Error.sol
@@ -41,3 +41,7 @@ error AvatarCIDCannotBeEmpty();
 error InsufficentPostFunds();
 
 error PostAlreadyPurchased();
+
+error PostNotPaywalled();
+
+error CreatorCannotPayForOwnContent();

--- a/packages/foundry/contracts/Events.sol
+++ b/packages/foundry/contracts/Events.sol
@@ -51,3 +51,5 @@ event TokenBurned(address indexed account, uint256 amount);
 /// @param postId The id of the post
 /// @param content The content of the comment
 event CommentAdded(address indexed commenter, bytes indexed postId, string content, uint256 createdAt);
+
+event PostPurchased(address indexed purchaser, bytes indexed postId);

--- a/packages/foundry/contracts/PostLib.sol
+++ b/packages/foundry/contracts/PostLib.sol
@@ -20,18 +20,17 @@ library PostLib {
     uint256 upvoteCount;
     uint256 downvoteCount;
   }
+  // TODO: Add a community pointer
+  /* NICE TO HAVE:
+      If we want to get fancy, we can ensure uniqueness by requiring post creation to include a nonce that is equal to 
+      exactly 1 + userProfile.postNonce
+  */
 
   struct Comment {
     address commenter;
     string content;
     uint256 createdAt;
   }
-  // TODO: Add a community pointer
-  // TODO: Add comments
-  /* NICE TO HAVE: 
-      If we want to get fancy, we can ensure uniqueness by requiring post creation to include a nonce that is equal to 
-      exactly 1 + userProfile.postNonce
-  */
 
   function abiEncodePost(string memory _title, string memory _content, uint256 _nonce)
     internal

--- a/packages/foundry/contracts/Spotlight.sol
+++ b/packages/foundry/contracts/Spotlight.sol
@@ -5,6 +5,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import "forge-std/console.sol";
 import "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 import "./PostLib.sol";
 import "./Events.sol";
@@ -15,7 +16,7 @@ import "./Error.sol";
 /// @author Team
 /// @notice You can use this contract to manage user profiles and create posts.
 /// @dev This contract is intended to be deployed on Ethereum-compatible networks.
-contract Spotlight {
+contract Spotlight is ReentrancyGuard {
   uint256 public constant PAYWALL_COST = 0.1 ether;
 
   /// @notice The owner of the contract.
@@ -383,10 +384,27 @@ contract Spotlight {
     profiles[msg.sender].avatarCID = _cid;
   }
 
-  function purchasePost(bytes calldata _id, string calldata _pubkey) public payable onlyRegistered postExists(_id) {
+  function hasPurchasedPost(bytes calldata _id) public view onlyRegistered postExists(_id) returns (bool) {
+    /**
+     * TODO: This needs to be modified, i.e. if the creator accepts your payment - it wouldn't be "PENDING"
+     * anymore - it would be in the user's mapping storing their copy of the post, which they can decrypt.
+     * That data structure doesn't exist yet...
+     */
+    return bytes(postsPendingPurchase[_id][msg.sender]).length > 0;
+  }
+
+  function purchasePost(bytes calldata _id, string calldata _pubkey)
+    public
+    payable
+    onlyRegistered
+    postExists(_id)
+    nonReentrant
+  {
+    if (!postStore[_id].paywalled) revert PostNotPaywalled();
+    if (msg.sender == postStore[_id].creator) revert CreatorCannotPayForOwnContent();
     if (msg.value < PAYWALL_COST) revert InsufficentPostFunds();
     if (bytes(postsPendingPurchase[_id][msg.sender]).length > 0) revert PostAlreadyPurchased();
     postsPendingPurchase[_id][msg.sender] = _pubkey;
-    // TODO: emit PostPurchased(msg.sender, _id)
+    emit PostPurchased(msg.sender, _id);
   }
 }

--- a/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { InheritanceTooltip } from "./InheritanceTooltip";
 import { Abi, AbiFunction } from "abitype";
 import { Address } from "viem";
-import { useReadContract } from "wagmi";
+import { useAccount, useReadContract } from "wagmi";
 import {
   ContractInput,
   displayTxResult,
@@ -32,8 +32,10 @@ export const ReadOnlyFunctionForm = ({
   const [form, setForm] = useState<Record<string, any>>(() => getInitialFormState(abiFunction));
   const [result, setResult] = useState<unknown>();
   const { targetNetwork } = useTargetNetwork();
+  const { address: userAddress } = useAccount();
 
   const { isFetching, refetch, error } = useReadContract({
+    account: userAddress,
     address: contractAddress,
     functionName: abiFunction.name,
     abi: abi,

--- a/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
@@ -38,6 +38,7 @@ export const WriteOnlyFunctionForm = ({
   const writeTxn = useTransactor();
   const { targetNetwork } = useTargetNetwork();
   const writeDisabled = !chain || chain?.id !== targetNetwork.id;
+  const { address: userAddress } = useAccount();
 
   const { data: result, isPending, writeContractAsync } = useWriteContract();
 
@@ -46,6 +47,7 @@ export const WriteOnlyFunctionForm = ({
       try {
         const makeWriteWithParams = () =>
           writeContractAsync({
+            account: userAddress,
             address: contractAddress,
             functionName: abiFunction.name,
             abi: abi,

--- a/packages/nextjs/components/post/Header.tsx
+++ b/packages/nextjs/components/post/Header.tsx
@@ -45,14 +45,16 @@ const PostHeader = ({
       <CreatorDisplay post={post} />
 
       <div className="flex gap-2">
+        <>
+          {post.paywalled && paywallSupported && !decrypted && (
+            <button className="btn btn-danger btn-sm" onClick={e => onClickUnlockPost(e)}>
+              <Image alt="Unlock Post" className="cursor-pointer" width="20" height="25" src="/lock-open.svg" />
+            </button>
+          )}
+        </>
         {address === post.creator && showPostMgmt && (
           <>
             {/* TODO: Think about support for editing paywalled post... */}
-            {post.paywalled && paywallSupported && !decrypted && (
-              <button className="btn btn-danger btn-sm" onClick={e => onClickUnlockPost(e)}>
-                <Image alt="Unlock Post" className="cursor-pointer" width="20" height="25" src="/lock-open.svg" />
-              </button>
-            )}
             {!post.paywalled && (
               <button className="btn btn-danger btn-sm" onClick={e => onClickEditPost(e)} disabled={editing}>
                 <Image alt="Edit Post" className="cursor-pointer" width="20" height="25" src="/pencil.svg" />

--- a/packages/nextjs/components/post/Post.tsx
+++ b/packages/nextjs/components/post/Post.tsx
@@ -3,7 +3,7 @@ import PostDeleteModal from "./DeleteModal";
 import PostEditModal from "./EditModal";
 import PostFooter from "./Footer";
 import PostHeader from "./Header";
-import { Hex } from "viem";
+import { Hex, toHex } from "viem";
 import { useAccount } from "wagmi";
 import Viewer from "~~/app/feed/richTextEditor/Viewer";
 import { PostDisplayContext } from "~~/contexts/Post";
@@ -37,12 +37,11 @@ const Post = ({ postId }: { postId: Hex }) => {
   const onClickUnlockPost = async (evt: React.MouseEvent<HTMLButtonElement>) => {
     evt.stopPropagation();
     if (address == post.creator) {
-      // sleep for 500ms - metamask gets unhappy if you spam it with back-2-back reqs
-      // await new Promise(f => setTimeout(f, 500));
       try {
+        // TODO: use a util for this
         const decryptedContent = await window.ethereum.request({
           method: "eth_decrypt",
-          params: [`0x${Buffer.from(post.content, "utf8").toString("hex")}`, address],
+          params: [toHex(Buffer.from(post.content, "utf8")), address],
         });
         setContent(decryptedContent);
         setDecrypted(true);
@@ -50,7 +49,24 @@ const Post = ({ postId }: { postId: Hex }) => {
         console.log(e);
       }
     } else {
-      alert("Purchasing paywalled content coming soon...");
+      try {
+        // TODO: !!!Check if user has already payed for post!!!
+
+        // TODO: util for this
+        const publicKey = await window.ethereum.request({
+          method: "eth_getEncryptionPublicKey",
+          params: [address.toLowerCase()],
+        });
+
+        console.log("pubKey for encryption:", publicKey);
+        console.log("i want to pay for", post.id);
+
+        // sleep for 500ms - metamask gets unhappy if you spam it with back-2-back reqs
+        // await new Promise(f => setTimeout(f, 500));
+        console.log("calling Spotlight.purchasePost");
+      } catch (e) {
+        console.log(e);
+      }
     }
   };
 

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -7,7 +7,7 @@ import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 const deployedContracts = {
   31337: {
     Spotlight: {
-      address: "0xa513e6e4b8f2a923d98304ec87f64353c4d5c853",
+      address: "0x5fbdb2315678afecb367f032d93f642f64180aa3",
       abi: [
         {
           type: "constructor",

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -22,6 +22,19 @@ const deployedContracts = {
         },
         {
           type: "function",
+          name: "PAYWALL_COST",
+          inputs: [],
+          outputs: [
+            {
+              name: "",
+              type: "uint256",
+              internalType: "uint256",
+            },
+          ],
+          stateMutability: "view",
+        },
+        {
+          type: "function",
           name: "addComment",
           inputs: [
             {
@@ -442,6 +455,25 @@ const deployedContracts = {
         },
         {
           type: "function",
+          name: "hasPurchasedPost",
+          inputs: [
+            {
+              name: "_id",
+              type: "bytes",
+              internalType: "bytes",
+            },
+          ],
+          outputs: [
+            {
+              name: "",
+              type: "bool",
+              internalType: "bool",
+            },
+          ],
+          stateMutability: "view",
+        },
+        {
+          type: "function",
           name: "isRegistered",
           inputs: [
             {
@@ -471,6 +503,24 @@ const deployedContracts = {
             },
           ],
           stateMutability: "view",
+        },
+        {
+          type: "function",
+          name: "purchasePost",
+          inputs: [
+            {
+              name: "_id",
+              type: "bytes",
+              internalType: "bytes",
+            },
+            {
+              name: "_pubkey",
+              type: "string",
+              internalType: "string",
+            },
+          ],
+          outputs: [],
+          stateMutability: "payable",
         },
         {
           type: "function",
@@ -657,6 +707,25 @@ const deployedContracts = {
         },
         {
           type: "event",
+          name: "PostPurchased",
+          inputs: [
+            {
+              name: "purchaser",
+              type: "address",
+              indexed: true,
+              internalType: "address",
+            },
+            {
+              name: "postId",
+              type: "bytes",
+              indexed: true,
+              internalType: "bytes",
+            },
+          ],
+          anonymous: false,
+        },
+        {
+          type: "event",
           name: "PostUpvoted",
           inputs: [
             {
@@ -742,6 +811,16 @@ const deployedContracts = {
         },
         {
           type: "error",
+          name: "CreatorCannotPayForOwnContent",
+          inputs: [],
+        },
+        {
+          type: "error",
+          name: "InsufficentPostFunds",
+          inputs: [],
+        },
+        {
+          type: "error",
           name: "InvalidSignature",
           inputs: [],
         },
@@ -752,7 +831,17 @@ const deployedContracts = {
         },
         {
           type: "error",
+          name: "PostAlreadyPurchased",
+          inputs: [],
+        },
+        {
+          type: "error",
           name: "PostNotFound",
+          inputs: [],
+        },
+        {
+          type: "error",
+          name: "PostNotPaywalled",
           inputs: [],
         },
         {
@@ -763,6 +852,11 @@ const deployedContracts = {
         {
           type: "error",
           name: "ProfileNotExist",
+          inputs: [],
+        },
+        {
+          type: "error",
+          name: "ReentrancyGuardReentrantCall",
           inputs: [],
         },
         {
@@ -806,6 +900,19 @@ const deployedContracts = {
         },
         {
           type: "function",
+          name: "PAYWALL_COST",
+          inputs: [],
+          outputs: [
+            {
+              name: "",
+              type: "uint256",
+              internalType: "uint256",
+            },
+          ],
+          stateMutability: "view",
+        },
+        {
+          type: "function",
           name: "addComment",
           inputs: [
             {
@@ -1226,6 +1333,25 @@ const deployedContracts = {
         },
         {
           type: "function",
+          name: "hasPurchasedPost",
+          inputs: [
+            {
+              name: "_id",
+              type: "bytes",
+              internalType: "bytes",
+            },
+          ],
+          outputs: [
+            {
+              name: "",
+              type: "bool",
+              internalType: "bool",
+            },
+          ],
+          stateMutability: "view",
+        },
+        {
+          type: "function",
           name: "isRegistered",
           inputs: [
             {
@@ -1255,6 +1381,24 @@ const deployedContracts = {
             },
           ],
           stateMutability: "view",
+        },
+        {
+          type: "function",
+          name: "purchasePost",
+          inputs: [
+            {
+              name: "_id",
+              type: "bytes",
+              internalType: "bytes",
+            },
+            {
+              name: "_pubkey",
+              type: "string",
+              internalType: "string",
+            },
+          ],
+          outputs: [],
+          stateMutability: "payable",
         },
         {
           type: "function",
@@ -1441,6 +1585,25 @@ const deployedContracts = {
         },
         {
           type: "event",
+          name: "PostPurchased",
+          inputs: [
+            {
+              name: "purchaser",
+              type: "address",
+              indexed: true,
+              internalType: "address",
+            },
+            {
+              name: "postId",
+              type: "bytes",
+              indexed: true,
+              internalType: "bytes",
+            },
+          ],
+          anonymous: false,
+        },
+        {
+          type: "event",
           name: "PostUpvoted",
           inputs: [
             {
@@ -1526,6 +1689,16 @@ const deployedContracts = {
         },
         {
           type: "error",
+          name: "CreatorCannotPayForOwnContent",
+          inputs: [],
+        },
+        {
+          type: "error",
+          name: "InsufficentPostFunds",
+          inputs: [],
+        },
+        {
+          type: "error",
           name: "InvalidSignature",
           inputs: [],
         },
@@ -1536,7 +1709,17 @@ const deployedContracts = {
         },
         {
           type: "error",
+          name: "PostAlreadyPurchased",
+          inputs: [],
+        },
+        {
+          type: "error",
           name: "PostNotFound",
+          inputs: [],
+        },
+        {
+          type: "error",
+          name: "PostNotPaywalled",
           inputs: [],
         },
         {
@@ -1547,6 +1730,11 @@ const deployedContracts = {
         {
           type: "error",
           name: "ProfileNotExist",
+          inputs: [],
+        },
+        {
+          type: "error",
+          name: "ReentrancyGuardReentrantCall",
           inputs: [],
         },
         {


### PR DESCRIPTION
* Create some storage on the contract to keep track of user's that have paid for a post
* Contract also receives & stores the public key of the purchaser that should be used to encrypt upon acceptance of payment
* Contract has a helper method for the UI to determine if you have a pending payment for a purchase (don't let people double pay for a post)
* Hard-coded a flat `0.1 ether` cost to posts - we can let users eventually set it as a future iteration if we want to get super fancy
* 

Extras:
* Update debug contract interface to support read & write contract methods