### PR TITLE
Contract size reduction - create separate `Posts` contract

### DIFF
--- a/packages/foundry/contracts/Error.sol
+++ b/packages/foundry/contracts/Error.sol
@@ -45,3 +45,5 @@ error PostAlreadyPurchased();
 error PostNotPaywalled();
 
 error CreatorCannotPayForOwnContent();
+
+error OnlySpotlightCanManagePosts();

--- a/packages/foundry/contracts/Error.sol
+++ b/packages/foundry/contracts/Error.sol
@@ -47,3 +47,13 @@ error PostNotPaywalled();
 error CreatorCannotPayForOwnContent();
 
 error OnlySpotlightCanManagePosts();
+
+error ReputationAddressCannotBeZero();
+
+error PostCreatorCannotBeZero();
+
+error CommentCannotBeEmpty();
+
+error OnlyCreatorCanDeclinePurchase();
+
+error NoPendingPurchaseFound();

--- a/packages/foundry/contracts/Posts.sol
+++ b/packages/foundry/contracts/Posts.sol
@@ -5,8 +5,6 @@ import "./Error.sol";
 import "./PostLib.sol";
 import "./Reputation.sol";
 
-// TODO: NEEDS ACCESS TO REPUTATION TOKEN!
-
 contract Posts {
   address public immutable spotlightContract;
   /// @notice Reputation token contract

--- a/packages/foundry/contracts/Posts.sol
+++ b/packages/foundry/contracts/Posts.sol
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+
+import "./PostLib.sol";
+import "./Error.sol";
+
+// TODO: NEEDS ACCESS TO REPUTATION TOKEN!
+
+contract Posts {
+  address public immutable spotlightContract;
+
+  // TODO: Support >1 community
+  /* TODO:
+       We should probably uses openzeppelin's DoubleEndedQueue here
+       https://docs.openzeppelin.com/contracts/5.x/api/utils#DoubleEndedQueue
+
+       An array adds to the end, so newer items are in the "back", forcing full traversal for
+       "the latest" posts.
+
+       Where as with a DoubleEndedQueue, all ops are O(1) and would work nicely with pagination
+    */
+  /// @dev Array of all post signatures in the community
+  bytes[] internal communityPostIDs;
+
+  /// @dev Mapping from address to it's post IDs
+  mapping(address => bytes[]) internal profilePostIDs;
+
+  // TODO: Move to off-chain storage - sig => off-chain storage location
+  /// @dev Mapping from signature of post (post ID) to post content
+  mapping(bytes => PostLib.Post) internal postStore;
+  mapping(bytes => PostLib.Comment[]) internal postComments;
+
+  // @notice Mappings of post IDs to the addresses that up/downvoted them
+  mapping(bytes => mapping(address => bool)) public upvotedBy;
+  mapping(bytes => mapping(address => bool)) public downvotedBy;
+
+  /// @dev post ID => wallet addr => pubKey for encryption
+  mapping(bytes => mapping(address => string)) internal purchaserPublicKeys;
+
+  /// @dev Pointer struct for traversal of purchaserPublicKeys
+  struct PendingPurchase {
+    address purchaser;
+    bytes postId;
+    string pubkey;
+  }
+
+  // Map of creator address => list of (users + posts) have they paid for?
+  mapping(address => PendingPurchase[]) internal pendingPurchases;
+
+  constructor(address _spotlightContract) {
+    if (_spotlightContract == address(0)) revert SpotlightAddressCannotBeZero();
+    spotlightContract = _spotlightContract;
+  }
+
+  function checkPostExists(bytes memory _id) internal view {
+    PostLib.Post memory post = postStore[_id];
+    if (bytes(post.content).length == 0) {
+      revert PostNotFound();
+    }
+  }
+
+  /// @notice Create a post from the caller's address.
+  /// @param _title The title of the post.
+  /// @param _content The content of the post.
+  /// @param _nonce The nonce used for signature generation
+  /// @param _sig The signature of the post.
+  function createPost(
+    address _addr,
+    string memory _title,
+    string memory _content,
+    uint256 _nonce,
+    bytes calldata _sig,
+    bool _paywalled
+  ) public {
+    if (msg.sender != spotlightContract) revert OnlySpotlightCanManagePosts();
+    if (bytes(_content).length == 0) revert ContentCannotBeEmpty();
+    if (bytes(_title).length == 0) revert TitleCannotBeEmpty();
+    if (!PostLib.isValidPostSignature(_addr, _title, _content, _nonce, _sig)) revert InvalidSignature();
+
+    // TODO: Check that the signature doesn't already exist in the postStore!
+
+    PostLib.Post memory p = PostLib.Post({
+      creator: _addr,
+      title: _title,
+      content: _content,
+      id: _sig,
+      signature: _sig,
+      nonce: _nonce,
+      paywalled: _paywalled,
+      createdAt: block.timestamp,
+      lastUpdatedAt: block.timestamp,
+      upvoteCount: 0,
+      downvoteCount: 0
+    });
+
+    postStore[_sig] = p;
+    communityPostIDs.push(_sig);
+    profilePostIDs[_addr].push(_sig);
+  }
+
+  /// @notice Get all posts for a given address
+  /// @param _addr Wallet address of the registered user whose posts we wish to retrieve
+  function getPostsOfAddress(address _addr) public view returns (PostLib.Post[] memory) {
+    // TODO: Add pagination - https://programtheblockchain.com/posts/2018/04/20/storage-patterns-pagination/
+    bytes[] memory sigs = profilePostIDs[_addr];
+    PostLib.Post[] memory userPosts = new PostLib.Post[](sigs.length);
+    for (uint256 i = 0; i < sigs.length; i++) {
+      // NOTE: Cannot use userPosts.push because push is only for dynamic arrays in STORAGE
+      userPosts[i] = postStore[sigs[i]];
+    }
+    return userPosts;
+  }
+
+  function getPost(bytes calldata _post_sig) public view returns (PostLib.Post memory) {
+    PostLib.Post memory p = postStore[_post_sig];
+    if (p.creator == address(0)) revert PostNotFound();
+    return p;
+  }
+
+  // TODO: add community ID argument - what community are you trying to get posts for?
+  /// @notice Get all posts from a community
+  function getCommunityPosts() public view returns (PostLib.Post[] memory) {
+    // TODO: Add pagination - https://programtheblockchain.com/posts/2018/04/20/storage-patterns-pagination/
+    PostLib.Post[] memory p = new PostLib.Post[](communityPostIDs.length);
+    for (uint256 i = 0; i < communityPostIDs.length; i++) {
+      p[i] = postStore[communityPostIDs[i]];
+    }
+    return p;
+  }
+
+  function editPost(address _addr, bytes calldata _id, string calldata newContent) public {
+    // Ensure post exists
+    if (msg.sender != spotlightContract) revert OnlySpotlightCanManagePosts();
+    checkPostExists(_id);
+    PostLib.Post storage post = postStore[_id];
+    if (post.creator != _addr) revert OnlyCreatorCanEdit();
+    if (bytes(newContent).length == 0) revert ContentCannotBeEmpty();
+
+    // TODO: Accept newSig arg and verify it against newContent
+
+    post.content = newContent;
+    post.lastUpdatedAt = block.timestamp;
+  }
+
+  function deletePost(address _addr, bytes memory _id) public {
+    // Ensure the post exists
+    if (msg.sender != spotlightContract) revert OnlySpotlightCanManagePosts();
+    checkPostExists(_id);
+    PostLib.Post storage post = postStore[_id];
+    if (post.creator != _addr) revert OnlyCreatorCanEdit();
+
+    // TODO: Burn RPT associated with the post (or at least burn some amount of RPT...)
+
+    // Remove post from user's profile
+    bytes[] storage userPosts = profilePostIDs[_addr];
+    for (uint256 i = 0; i < userPosts.length; i++) {
+      // Solidity doesn’t have native string comparison, so keccak256 is often used to compare strings by hashing them
+      if (keccak256(userPosts[i]) == keccak256(_id)) {
+        userPosts[i] = userPosts[userPosts.length - 1]; // Efficient gas usage: O(1) rather than O(n).
+        userPosts.pop();
+        break;
+      }
+    }
+
+    deleteCommunityPost(_id);
+    delete postStore[_id];
+  }
+
+  function deleteProfile(address _addr) public {
+    if (msg.sender != spotlightContract) revert OnlySpotlightCanManagePosts();
+    for (uint256 i = 0; i < profilePostIDs[_addr].length; ++i) {
+      bytes memory id = profilePostIDs[_addr][i];
+      deleteCommunityPost(id);
+      delete postStore[id];
+    }
+
+    // TODO: Burn remaining reputation of user
+
+    delete profilePostIDs[_addr];
+  }
+
+  function deleteCommunityPost(bytes memory _id) internal {
+    // Remove post from communityPostIDs
+    checkPostExists(_id);
+    for (uint256 i = 0; i < communityPostIDs.length; i++) {
+      // Solidity doesn’t have native string comparison, so keccak256 is often used to compare strings by hashing them
+      if (keccak256(communityPostIDs[i]) == keccak256(_id)) {
+        communityPostIDs[i] = communityPostIDs[communityPostIDs.length - 1]; // Efficient gas usage: O(1) rather than O(n).
+        communityPostIDs.pop();
+        break;
+      }
+    }
+  }
+
+  function upvote(address _addr, bytes calldata _id) public {
+    if (msg.sender != spotlightContract) revert OnlySpotlightCanManagePosts();
+    checkPostExists(_id);
+    PostLib.Post storage p = postStore[_id];
+    if (upvotedBy[_id][_addr]) {
+      p.upvoteCount--;
+      //   reputationToken.revertUpvotePost(p.creator);
+      delete upvotedBy[_id][_addr];
+      return;
+    }
+
+    if (downvotedBy[_id][_addr]) {
+      p.downvoteCount--;
+      //   reputationToken.revertDownvotePost(p.creator);
+      delete downvotedBy[_id][_addr];
+    }
+
+    p.upvoteCount++;
+    upvotedBy[_id][_addr] = true;
+    // reputationToken.upvotePost(p.creator);
+  }
+
+  function downvote(address _addr, bytes calldata _id) public {
+    if (msg.sender != spotlightContract) revert OnlySpotlightCanManagePosts();
+    checkPostExists(_id);
+    PostLib.Post storage p = postStore[_id];
+    if (downvotedBy[_id][_addr]) {
+      p.downvoteCount--;
+      //   reputationToken.revertDownvotePost(p.creator);
+      delete downvotedBy[_id][_addr];
+      return;
+    }
+
+    if (upvotedBy[_id][_addr]) {
+      // TODO: undo upvote in reputationToken
+      p.upvoteCount--;
+      //   reputationToken.revertUpvotePost(p.creator);
+      delete upvotedBy[_id][_addr];
+    }
+
+    p.downvoteCount++;
+    downvotedBy[_id][_addr] = true;
+    // reputationToken.downvotePost(p.creator);
+  }
+
+  function addComment(address _addr, bytes calldata _id, string calldata _content) public {
+    if (msg.sender != spotlightContract) revert OnlySpotlightCanManagePosts();
+    checkPostExists(_id);
+    require(bytes(_content).length > 0, "Comment cannot be empty");
+
+    PostLib.Comment memory newComment =
+      PostLib.Comment({ commenter: _addr, content: _content, createdAt: block.timestamp });
+
+    postComments[_id].push(newComment);
+  }
+
+  function getComments(bytes calldata _id) public view returns (PostLib.Comment[] memory) {
+    checkPostExists(_id);
+    return postComments[_id];
+  }
+
+  //   function isPurchasePending(bytes calldata _id) public view onlyRegistered postExists(_id) returns (bool) {
+  //     /**
+  //      * TODO: This needs to be modified, i.e. if the creator accepts your payment - it wouldn't be "PENDING"
+  //      * anymore - it would be in the user's mapping storing their copy of the post, which they can decrypt.
+  //      * That data structure doesn't exist yet...
+  //      */
+  //     return bytes(purchaserPublicKeys[_id][msg.sender]).length > 0;
+  //   }
+
+  //   function purchasePost(bytes calldata _id, string calldata _pubkey)
+  //     public
+  //     payable
+  //     onlyRegistered
+  //     postExists(_id)
+  //     nonReentrant
+  //   {
+  //     if (!postStore[_id].paywalled) revert PostNotPaywalled();
+  //     if (msg.sender == postStore[_id].creator) revert CreatorCannotPayForOwnContent();
+  //     if (msg.value < PAYWALL_COST) revert InsufficentPostFunds();
+
+  //     // TODO: This will need to be modified - same reason(s) stated in `hasPurchasedPost` above
+  //     if (bytes(purchaserPublicKeys[_id][msg.sender]).length > 0) revert PostAlreadyPurchased();
+
+  //     purchaserPublicKeys[_id][msg.sender] = _pubkey;
+  //     pendingPurchases[postStore[_id].creator].push(PendingPurchase(msg.sender, _id, _pubkey));
+  //     emit PostPurchased(msg.sender, _id);
+  //   }
+
+  //   function getPendingPurchases() public view onlyRegistered returns (PendingPurchase[] memory) {
+  //     return pendingPurchases[msg.sender];
+  //   }
+
+  //   function declinePurchase(bytes calldata _id, address payable purchaser)
+  //     public
+  //     onlyRegistered
+  //     postExists(_id)
+  //     nonReentrant
+  //   {
+  //     // TODO: Only the owner of the post can decline a purchase
+  //     // TODO: Make sure the contract has the funds to handle the refund of the decline
+  //     purchaser.transfer(0.1 ether);
+
+  //     for (uint256 i = 0; i < pendingPurchases[msg.sender].length; i++) {
+  //       if (keccak256(pendingPurchases[msg.sender][i].postId) == keccak256(_id)) {
+  //         pendingPurchases[msg.sender][i] = pendingPurchases[msg.sender][pendingPurchases[msg.sender].length - 1];
+  //         pendingPurchases[msg.sender].pop();
+  //         break;
+  //       }
+  //     }
+  //     delete purchaserPublicKeys[_id][purchaser];
+  //   }
+}

--- a/packages/foundry/contracts/Reputation.sol
+++ b/packages/foundry/contracts/Reputation.sol
@@ -18,6 +18,8 @@ contract Reputation is ERC20 {
   }
 
   function setPostsContract(address _addr) public {
+    // TODO: Better error message
+    // TODO: Unit test
     if (msg.sender != spotlightContract) revert OnlySpotlightContractCanIssueTokens();
     if (_addr == address(0)) revert CannotIssueToZeroAddress();
     postsContract = _addr;

--- a/packages/foundry/contracts/Reputation.sol
+++ b/packages/foundry/contracts/Reputation.sol
@@ -7,6 +7,7 @@ import "./Error.sol";
 
 contract Reputation is ERC20 {
   address public immutable spotlightContract;
+  address private postsContract;
   uint256 private constant DECAY_INTERVAL = 15 minutes;
   uint256 private constant DECAY_RATE = 1; // 1% decay every 15 minutes
   mapping(address => uint256) private lastDecayTime;
@@ -14,6 +15,23 @@ contract Reputation is ERC20 {
   constructor(address _spotlightContract) ERC20("Reputation", "RPT") {
     if (_spotlightContract == address(0)) revert SpotlightAddressCannotBeZero();
     spotlightContract = _spotlightContract;
+  }
+
+  function setPostsContract(address _addr) public {
+    if (msg.sender != spotlightContract) revert OnlySpotlightContractCanIssueTokens();
+    if (_addr == address(0)) revert CannotIssueToZeroAddress();
+    postsContract = _addr;
+  }
+
+  function isAllowed(address _addr) private view returns (bool) {
+    if (_addr == spotlightContract) {
+      return true;
+    }
+
+    if (_addr == postsContract) {
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -54,7 +72,7 @@ contract Reputation is ERC20 {
    * @param receiver The address that will receive the tokens
    */
   function upvotePost(address receiver) external {
-    if (msg.sender != spotlightContract) revert OnlySpotlightContractCanIssueTokens();
+    if (!isAllowed(msg.sender)) revert OnlySpotlightContractCanIssueTokens();
     _applyDecay(receiver); // Apply decay before issuing new tokens
     _issueToken(receiver, 100);
   }
@@ -64,7 +82,7 @@ contract Reputation is ERC20 {
    * @param receiver The address that will lose the tokens
    */
   function revertUpvotePost(address receiver) external {
-    if (msg.sender != spotlightContract) revert OnlySpotlightContractCanIssueTokens();
+    if (!isAllowed(msg.sender)) revert OnlySpotlightContractCanIssueTokens();
     _applyDecay(receiver); // Apply decay before burning new tokens
     _burnToken(receiver, 100);
   }
@@ -74,7 +92,7 @@ contract Reputation is ERC20 {
    * @param receiver The address that will receive the tokens
    */
   function upvoteComment(address receiver) external {
-    if (msg.sender != spotlightContract) revert OnlySpotlightContractCanIssueTokens();
+    if (!isAllowed(msg.sender)) revert OnlySpotlightContractCanIssueTokens();
     _applyDecay(receiver); // Apply decay before issuing new tokens
     _issueToken(receiver, 10);
   }
@@ -84,7 +102,7 @@ contract Reputation is ERC20 {
    * @param account The address from which tokens will be burned
    */
   function revertDownvotePost(address account) external {
-    if (msg.sender != spotlightContract) revert OnlySpotlightContractCanBurnTokens();
+    if (!isAllowed(msg.sender)) revert OnlySpotlightContractCanBurnTokens();
     _applyDecay(account); // Apply decay before issuing tokens
     if (balanceOf(account) >= 5 * 10 ** decimals()) {
       // Otherwise we're giving away 5 RPT
@@ -97,7 +115,7 @@ contract Reputation is ERC20 {
    * @param account The address from which tokens will be burned
    */
   function downvotePost(address account) external {
-    if (msg.sender != spotlightContract) revert OnlySpotlightContractCanBurnTokens();
+    if (!isAllowed(msg.sender)) revert OnlySpotlightContractCanBurnTokens();
     _applyDecay(account); // Apply decay before burning tokens
     _burnToken(account, 5);
   }
@@ -107,7 +125,7 @@ contract Reputation is ERC20 {
    * @param account The address from which tokens will be burned
    */
   function downvoteComment(address account) external {
-    if (msg.sender != spotlightContract) revert OnlySpotlightContractCanBurnTokens();
+    if (!isAllowed(msg.sender)) revert OnlySpotlightContractCanBurnTokens();
     _applyDecay(account); // Apply decay before burning tokens
     _burnToken(account, 1);
   }

--- a/packages/foundry/contracts/Spotlight.sol
+++ b/packages/foundry/contracts/Spotlight.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
+import "./Posts.sol";
 import "./PostLib.sol";
 import "./Events.sol";
 import "./Reputation.sol";
@@ -25,40 +26,8 @@ contract Spotlight is ReentrancyGuard {
   /// @notice Reputation token contract
   Reputation private reputationToken;
 
-  // @notice Mappings of post IDs to the addresses that up/downvoted them
-  mapping(bytes => mapping(address => bool)) public upvotedBy;
-  mapping(bytes => mapping(address => bool)) public downvotedBy;
-
-  // TODO: Move to off-chain storage - sig => off-chain storage location
-  /// @dev Mapping from signature of post (post ID) to post content
-  mapping(bytes => PostLib.Post) internal postStore;
-  mapping(bytes => PostLib.Comment[]) internal postComments;
-
-  /// @dev post ID => wallet addr => pubKey for encryption
-  mapping(bytes => mapping(address => string)) internal purchaserPublicKeys;
-
-  /// @dev Pointer struct for traversal of purchaserPublicKeys
-  struct PendingPurchase {
-    address purchaser;
-    bytes postId;
-    string pubkey;
-  }
-
-  // Map of creator address => list of (users + posts) have they paid for?
-  mapping(address => PendingPurchase[]) internal pendingPurchases;
-
-  // TODO: Support >1 community
-  /* TODO:
-       We should probably uses openzeppelin's DoubleEndedQueue here
-       https://docs.openzeppelin.com/contracts/5.x/api/utils#DoubleEndedQueue
-
-       An array adds to the end, so newer items are in the "back", forcing full traversal for
-       "the latest" posts.
-
-       Where as with a DoubleEndedQueue, all ops are O(1) and would work nicely with pagination
-    */
-  /// @dev Array of all post signatures in the community
-  bytes[] internal communityPostIDs;
+  /// @notice Posts contract
+  Posts private postsContract;
 
   /// @notice Structure to store profile information.
   struct Profile {
@@ -67,9 +36,6 @@ contract Spotlight is ReentrancyGuard {
     string avatarCID; // IPFS CID
     uint256 reputation;
   }
-
-  /// @dev Mapping from address to it's post IDs
-  mapping(address => bytes[]) internal profilePostIDs;
 
   /// @dev Mapping from an address to its associated profile.
   mapping(address => Profile) internal profiles;
@@ -82,19 +48,12 @@ contract Spotlight is ReentrancyGuard {
   constructor(address _owner) {
     owner = _owner;
     reputationToken = new Reputation(address(this));
+    postsContract = new Posts(address(this));
   }
 
   /// @notice Modifier to ensure that only registered users can perform certain actions.
   modifier onlyRegistered() {
     if (!isRegistered(msg.sender)) revert ProfileNotExist();
-    _;
-  }
-
-  modifier postExists(bytes memory _id) {
-    PostLib.Post memory post = postStore[_id];
-    if (bytes(post.content).length == 0) {
-      revert PostNotFound();
-    }
     _;
   }
 
@@ -163,21 +122,18 @@ contract Spotlight is ReentrancyGuard {
     emit ProfileUpdated(msg.sender, _newUsername);
   }
 
+  function updateAvatarCID(string calldata _cid) public onlyRegistered {
+    if (bytes(_cid).length == 0) revert AvatarCIDCannotBeEmpty();
+    profiles[msg.sender].avatarCID = _cid;
+  }
+
   /// @notice Delete the caller's profile.
   /// @dev The profile is removed and its associated username is freed.
   function deleteProfile() public onlyRegistered {
     bytes32 oldHash = _getUsernameHash(profiles[msg.sender].username);
     normalized_username_hashes[oldHash] = false;
 
-    for (uint256 i = 0; i < profilePostIDs[msg.sender].length; ++i) {
-      bytes memory id = profilePostIDs[msg.sender][i];
-      deleteCommunityPost(id);
-      delete postStore[id];
-    }
-
-    // TODO: Burn remaining reputation of user
-
-    delete profilePostIDs[msg.sender];
+    postsContract.deleteProfile(msg.sender);
     delete profiles[msg.sender];
     emit ProfileDeleted(msg.sender);
   }
@@ -224,207 +180,96 @@ contract Spotlight is ReentrancyGuard {
     bytes calldata _sig,
     bool _paywalled
   ) public onlyRegistered {
-    if (bytes(_content).length == 0) revert ContentCannotBeEmpty();
-    if (bytes(_title).length == 0) revert TitleCannotBeEmpty();
-    if (!PostLib.isValidPostSignature(msg.sender, _title, _content, _nonce, _sig)) revert InvalidSignature();
-
-    // TODO: Check that the signature doesn't already exist in the postStore!
-
-    PostLib.Post memory p = PostLib.Post({
-      creator: msg.sender,
-      title: _title,
-      content: _content,
-      id: _sig,
-      signature: _sig,
-      nonce: _nonce,
-      paywalled: _paywalled,
-      createdAt: block.timestamp,
-      lastUpdatedAt: block.timestamp,
-      upvoteCount: 0,
-      downvoteCount: 0
-    });
-
-    postStore[_sig] = p;
-    communityPostIDs.push(_sig);
-    profilePostIDs[msg.sender].push(_sig);
+    postsContract.createPost(msg.sender, _title, _content, _nonce, _sig, _paywalled);
     emit PostCreated(msg.sender, _sig);
   }
 
   /// @notice Get all posts for a given address
   /// @param _addr Wallet address of the registered user whose posts we wish to retrieve
   function getPostsOfAddress(address _addr) public view onlyRegistered returns (PostLib.Post[] memory) {
-    // TODO: Add pagination - https://programtheblockchain.com/posts/2018/04/20/storage-patterns-pagination/
-    if (!isRegistered(_addr)) revert AddressNotRegistered();
-
-    bytes[] memory sigs = profilePostIDs[_addr];
-    console.log("Sigs length", sigs.length);
-    PostLib.Post[] memory userPosts = new PostLib.Post[](sigs.length);
-    for (uint256 i = 0; i < sigs.length; i++) {
-      // NOTE: Cannot use userPosts.push because push is only for dynamic arrays in STORAGE
-      userPosts[i] = postStore[sigs[i]];
-    }
-    return userPosts;
+    return postsContract.getPostsOfAddress(_addr);
   }
 
   function getPost(bytes calldata _post_sig) public view onlyRegistered returns (PostLib.Post memory) {
-    PostLib.Post memory p = postStore[_post_sig];
-    if (p.creator == address(0)) revert PostNotFound();
-    return p;
+    return postsContract.getPost(_post_sig);
   }
 
   // TODO: add community ID argument - what community are you trying to get posts for?
   /// @notice Get all posts from a community
   function getCommunityPosts() public view onlyRegistered returns (PostLib.Post[] memory) {
     // TODO: Add pagination - https://programtheblockchain.com/posts/2018/04/20/storage-patterns-pagination/
-    PostLib.Post[] memory p = new PostLib.Post[](communityPostIDs.length);
-    for (uint256 i = 0; i < communityPostIDs.length; i++) {
-      p[i] = postStore[communityPostIDs[i]];
-    }
-    return p;
+    return postsContract.getCommunityPosts();
   }
 
-  function editPost(bytes calldata _id, string calldata newContent) public onlyRegistered postExists(_id) {
-    // Ensure post exists
-    PostLib.Post storage post = postStore[_id];
-    if (post.creator != msg.sender) revert OnlyCreatorCanEdit();
-    if (bytes(newContent).length == 0) revert ContentCannotBeEmpty();
-
-    // TODO: Accept newSig arg and verify it against newContent
-
-    post.content = newContent;
-    post.lastUpdatedAt = block.timestamp;
-
+  function editPost(bytes calldata _id, string calldata newContent) public onlyRegistered {
+    postsContract.editPost(msg.sender, _id, newContent);
     emit PostEdited(msg.sender, _id);
   }
 
-  function deletePost(bytes memory _id) public onlyRegistered postExists(_id) {
-    // Ensure the post exists
-    PostLib.Post storage post = postStore[_id];
-    if (post.creator != msg.sender) revert OnlyCreatorCanEdit();
-
-    // TODO: Burn RPT associated with the post (or at least burn some amount of RPT...)
-
-    // Remove post from user's profile
-    bytes[] storage userPosts = profilePostIDs[msg.sender];
-    for (uint256 i = 0; i < userPosts.length; i++) {
-      // Solidity doesn’t have native string comparison, so keccak256 is often used to compare strings by hashing them
-      if (keccak256(userPosts[i]) == keccak256(_id)) {
-        userPosts[i] = userPosts[userPosts.length - 1]; // Efficient gas usage: O(1) rather than O(n).
-        userPosts.pop();
-        break;
-      }
-    }
-
-    deleteCommunityPost(_id);
-    delete postStore[_id];
+  function deletePost(bytes memory _id) public onlyRegistered {
+    postsContract.deletePost(msg.sender, _id);
     emit PostDeleted(msg.sender, _id);
   }
 
-  function deleteCommunityPost(bytes memory _id) internal postExists(_id) {
-    // Remove post from communityPostIDs
-    for (uint256 i = 0; i < communityPostIDs.length; i++) {
-      // Solidity doesn’t have native string comparison, so keccak256 is often used to compare strings by hashing them
-      if (keccak256(communityPostIDs[i]) == keccak256(_id)) {
-        communityPostIDs[i] = communityPostIDs[communityPostIDs.length - 1]; // Efficient gas usage: O(1) rather than O(n).
-        communityPostIDs.pop();
-        break;
-      }
-    }
-  }
-
-  function upvote(bytes calldata _id) public onlyRegistered postExists(_id) {
-    PostLib.Post storage p = postStore[_id];
-    if (upvotedBy[_id][msg.sender]) {
-      p.upvoteCount--;
-      reputationToken.revertUpvotePost(p.creator);
-      delete upvotedBy[_id][msg.sender];
-      return;
-    }
-
-    if (downvotedBy[_id][msg.sender]) {
-      p.downvoteCount--;
-      reputationToken.revertDownvotePost(p.creator);
-      delete downvotedBy[_id][msg.sender];
-    }
-
-    p.upvoteCount++;
-    upvotedBy[_id][msg.sender] = true;
-    reputationToken.upvotePost(p.creator);
+  function upvote(bytes calldata _id) public onlyRegistered {
+    postsContract.upvote(msg.sender, _id);
     emit PostUpvoted(msg.sender, _id);
   }
 
-  function downvote(bytes calldata _id) public onlyRegistered postExists(_id) {
-    PostLib.Post storage p = postStore[_id];
-    if (downvotedBy[_id][msg.sender]) {
-      p.downvoteCount--;
-      reputationToken.revertDownvotePost(p.creator);
-      delete downvotedBy[_id][msg.sender];
-      return;
-    }
+  function upvotedBy(bytes calldata _id, address _addr) public view onlyRegistered returns (bool) {
+    return postsContract.upvotedBy(_id, _addr);
+  }
 
-    if (upvotedBy[_id][msg.sender]) {
-      // TODO: undo upvote in reputationToken
-      p.upvoteCount--;
-      reputationToken.revertUpvotePost(p.creator);
-      delete upvotedBy[_id][msg.sender];
-    }
-
-    p.downvoteCount++;
-    downvotedBy[_id][msg.sender] = true;
-    reputationToken.downvotePost(p.creator);
+  function downvote(bytes calldata _id) public onlyRegistered {
+    postsContract.downvote(msg.sender, _id);
     emit PostDownvoted(msg.sender, _id);
   }
 
-  function addComment(bytes calldata _id, string calldata _content) public onlyRegistered postExists(_id) {
-    require(bytes(_content).length > 0, "Comment cannot be empty");
+  function downvotedBy(bytes calldata _id, address _addr) public view onlyRegistered returns (bool) {
+    return postsContract.downvotedBy(_id, _addr);
+  }
 
-    PostLib.Comment memory newComment =
-      PostLib.Comment({ commenter: msg.sender, content: _content, createdAt: block.timestamp });
-
-    postComments[_id].push(newComment);
+  function addComment(bytes calldata _id, string calldata _content) public onlyRegistered {
+    postsContract.addComment(msg.sender, _id, _content);
     emit CommentAdded(msg.sender, _id, _content, block.timestamp);
   }
 
-  function getComments(bytes calldata _id) public view postExists(_id) returns (PostLib.Comment[] memory) {
-    return postComments[_id];
+  /// @notice Get comments for a given post ID
+  function getComments(bytes calldata _id) public view onlyRegistered returns (PostLib.Comment[] memory) {
+    return postsContract.getComments(_id);
   }
 
-  function updateAvatarCID(string calldata _cid) public onlyRegistered {
-    if (bytes(_cid).length == 0) revert AvatarCIDCannotBeEmpty();
-    profiles[msg.sender].avatarCID = _cid;
-  }
+  // function isPurchasePending(bytes calldata _id) public view onlyRegistered postExists(_id) returns (bool) {
+  //   /**
+  //    * TODO: This needs to be modified, i.e. if the creator accepts your payment - it wouldn't be "PENDING"
+  //    * anymore - it would be in the user's mapping storing their copy of the post, which they can decrypt.
+  //    * That data structure doesn't exist yet...
+  //    */
+  //   return bytes(purchaserPublicKeys[_id][msg.sender]).length > 0;
+  // }
 
-  function isPurchasePending(bytes calldata _id) public view onlyRegistered postExists(_id) returns (bool) {
-    /**
-     * TODO: This needs to be modified, i.e. if the creator accepts your payment - it wouldn't be "PENDING"
-     * anymore - it would be in the user's mapping storing their copy of the post, which they can decrypt.
-     * That data structure doesn't exist yet...
-     */
-    return bytes(purchaserPublicKeys[_id][msg.sender]).length > 0;
-  }
+  // function purchasePost(bytes calldata _id, string calldata _pubkey)
+  //   public
+  //   payable
+  //   onlyRegistered
+  //   postExists(_id)
+  //   nonReentrant
+  // {
+  //   if (!postStore[_id].paywalled) revert PostNotPaywalled();
+  //   if (msg.sender == postStore[_id].creator) revert CreatorCannotPayForOwnContent();
+  //   if (msg.value < PAYWALL_COST) revert InsufficentPostFunds();
 
-  function purchasePost(bytes calldata _id, string calldata _pubkey)
-    public
-    payable
-    onlyRegistered
-    postExists(_id)
-    nonReentrant
-  {
-    if (!postStore[_id].paywalled) revert PostNotPaywalled();
-    if (msg.sender == postStore[_id].creator) revert CreatorCannotPayForOwnContent();
-    if (msg.value < PAYWALL_COST) revert InsufficentPostFunds();
+  //   // TODO: This will need to be modified - same reason(s) stated in `hasPurchasedPost` above
+  //   if (bytes(purchaserPublicKeys[_id][msg.sender]).length > 0) revert PostAlreadyPurchased();
 
-    // TODO: This will need to be modified - same reason(s) stated in `hasPurchasedPost` above
-    if (bytes(purchaserPublicKeys[_id][msg.sender]).length > 0) revert PostAlreadyPurchased();
+  //   purchaserPublicKeys[_id][msg.sender] = _pubkey;
+  //   pendingPurchases[postStore[_id].creator].push(PendingPurchase(msg.sender, _id, _pubkey));
+  //   emit PostPurchased(msg.sender, _id);
+  // }
 
-    purchaserPublicKeys[_id][msg.sender] = _pubkey;
-    pendingPurchases[postStore[_id].creator].push(PendingPurchase(msg.sender, _id, _pubkey));
-    emit PostPurchased(msg.sender, _id);
-  }
-
-  function getPendingPurchases() public view onlyRegistered returns (PendingPurchase[] memory) {
-    return pendingPurchases[msg.sender];
-  }
+  // function getPendingPurchases() public view onlyRegistered returns (PendingPurchase[] memory) {
+  //   return pendingPurchases[msg.sender];
+  // }
 
   // function declinePurchase(bytes calldata _id, address payable purchaser)
   //   public

--- a/packages/foundry/test/Posts.t.sol
+++ b/packages/foundry/test/Posts.t.sol
@@ -208,32 +208,6 @@ contract PostManagementTest is Test {
     spotlight.getPostsOfAddress(_addr);
   }
 
-  function testUnregisteredUserCannotGetPostsOfAnotherUser() public {
-    PostLib.Post memory p = createTestPost();
-    vm.startPrank(wallet.addr);
-    spotlight.registerProfile("username");
-    spotlight.createPost(p.title, p.content, p.nonce, signContentViaWallet(wallet, p), false);
-    vm.stopPrank();
-
-    address _addr = vm.addr(2);
-    vm.startPrank(_addr);
-    vm.expectRevert(ProfileNotExist.selector);
-    spotlight.getPostsOfAddress(wallet.addr);
-  }
-
-  function testUnregisteredUserCannotSeePostsOfACommunity() public {
-    PostLib.Post memory p = createTestPost();
-    vm.startPrank(wallet.addr);
-    spotlight.registerProfile("username");
-    spotlight.createPost(p.title, p.content, p.nonce, signContentViaWallet(wallet, p), false);
-    vm.stopPrank();
-
-    address _addr = vm.addr(2);
-    vm.startPrank(_addr);
-    vm.expectRevert(ProfileNotExist.selector);
-    spotlight.getCommunityPosts();
-  }
-
   function testUserCanEditPostSuccess() public {
     vm.startPrank(wallet.addr);
     spotlight.registerProfile("username");

--- a/packages/foundry/test/Posts.t.sol
+++ b/packages/foundry/test/Posts.t.sol
@@ -367,88 +367,88 @@ contract PostManagementTest is Test {
     assertEq(comments[1].content, "Second comment.", "Second comment: content mismatch");
   }
 
-  function testCannotPurchasePostIfPostDoesNotExist() public {
-    vm.startPrank(wallet.addr);
-    spotlight.registerProfile("username");
+  // function testCannotPurchasePostIfPostDoesNotExist() public {
+  //   vm.startPrank(wallet.addr);
+  //   spotlight.registerProfile("username");
 
-    vm.expectRevert(PostNotFound.selector);
-    spotlight.purchasePost("does-not-exist", "pubkey");
-  }
+  //   vm.expectRevert(PostNotFound.selector);
+  //   spotlight.purchasePost("does-not-exist", "pubkey");
+  // }
 
-  function testCannotPurchasePostIfNotRegistered() public {
-    vm.startPrank(wallet.addr);
-    spotlight.registerProfile("username");
+  // function testCannotPurchasePostIfNotRegistered() public {
+  //   vm.startPrank(wallet.addr);
+  //   spotlight.registerProfile("username");
 
-    PostLib.Post memory post = createTestPost();
-    bytes memory signature = signContentViaWallet(wallet, post);
-    spotlight.createPost(post.title, post.content, post.nonce, signature, true);
-    vm.stopPrank();
+  //   PostLib.Post memory post = createTestPost();
+  //   bytes memory signature = signContentViaWallet(wallet, post);
+  //   spotlight.createPost(post.title, post.content, post.nonce, signature, true);
+  //   vm.stopPrank();
 
-    vm.startPrank(vm.addr(2));
-    vm.expectRevert(ProfileNotExist.selector);
-    spotlight.purchasePost(signature, "pubkey");
-  }
+  //   vm.startPrank(vm.addr(2));
+  //   vm.expectRevert(ProfileNotExist.selector);
+  //   spotlight.purchasePost(signature, "pubkey");
+  // }
 
-  function testCannotPurchasePostIfPostIsNotPaywalled() public {
-    vm.startPrank(wallet.addr);
-    spotlight.registerProfile("username");
+  // function testCannotPurchasePostIfPostIsNotPaywalled() public {
+  //   vm.startPrank(wallet.addr);
+  //   spotlight.registerProfile("username");
 
-    PostLib.Post memory post = createTestPost();
-    bytes memory signature = signContentViaWallet(wallet, post);
-    spotlight.createPost(post.title, post.content, post.nonce, signature, false);
-    vm.stopPrank();
+  //   PostLib.Post memory post = createTestPost();
+  //   bytes memory signature = signContentViaWallet(wallet, post);
+  //   spotlight.createPost(post.title, post.content, post.nonce, signature, false);
+  //   vm.stopPrank();
 
-    address otherUser = vm.addr(2);
-    vm.startPrank(otherUser);
-    spotlight.registerProfile("username2");
-    vm.expectRevert(PostNotPaywalled.selector);
-    spotlight.purchasePost(signature, "pubkey");
-  }
+  //   address otherUser = vm.addr(2);
+  //   vm.startPrank(otherUser);
+  //   spotlight.registerProfile("username2");
+  //   vm.expectRevert(PostNotPaywalled.selector);
+  //   spotlight.purchasePost(signature, "pubkey");
+  // }
 
-  function testCreatorCannotPayForTheirOwnContent() public {
-    vm.startPrank(wallet.addr);
-    spotlight.registerProfile("username");
+  // function testCreatorCannotPayForTheirOwnContent() public {
+  //   vm.startPrank(wallet.addr);
+  //   spotlight.registerProfile("username");
 
-    PostLib.Post memory post = createTestPost();
-    bytes memory signature = signContentViaWallet(wallet, post);
-    spotlight.createPost(post.title, post.content, post.nonce, signature, true);
-    vm.expectRevert(CreatorCannotPayForOwnContent.selector);
-    spotlight.purchasePost(signature, "pubkey");
-  }
+  //   PostLib.Post memory post = createTestPost();
+  //   bytes memory signature = signContentViaWallet(wallet, post);
+  //   spotlight.createPost(post.title, post.content, post.nonce, signature, true);
+  //   vm.expectRevert(CreatorCannotPayForOwnContent.selector);
+  //   spotlight.purchasePost(signature, "pubkey");
+  // }
 
-  function testUserCannotPurchasePostWithoutProperFunds() public {
-    vm.startPrank(wallet.addr);
-    spotlight.registerProfile("username");
+  // function testUserCannotPurchasePostWithoutProperFunds() public {
+  //   vm.startPrank(wallet.addr);
+  //   spotlight.registerProfile("username");
 
-    PostLib.Post memory post = createTestPost();
-    bytes memory signature = signContentViaWallet(wallet, post);
-    spotlight.createPost(post.title, post.content, post.nonce, signature, true);
+  //   PostLib.Post memory post = createTestPost();
+  //   bytes memory signature = signContentViaWallet(wallet, post);
+  //   spotlight.createPost(post.title, post.content, post.nonce, signature, true);
 
-    address otherUser = vm.addr(2);
-    vm.startPrank(otherUser);
-    spotlight.registerProfile("username2");
-    vm.expectRevert(InsufficentPostFunds.selector);
-    spotlight.purchasePost(signature, "pubkey");
-  }
+  //   address otherUser = vm.addr(2);
+  //   vm.startPrank(otherUser);
+  //   spotlight.registerProfile("username2");
+  //   vm.expectRevert(InsufficentPostFunds.selector);
+  //   spotlight.purchasePost(signature, "pubkey");
+  // }
 
-  function testUserCannotDoublePurchaseAPost() public {
-    vm.startPrank(wallet.addr);
-    spotlight.registerProfile("username");
+  // function testUserCannotDoublePurchaseAPost() public {
+  //   vm.startPrank(wallet.addr);
+  //   spotlight.registerProfile("username");
 
-    PostLib.Post memory post = createTestPost();
-    bytes memory signature = signContentViaWallet(wallet, post);
-    spotlight.createPost(post.title, post.content, post.nonce, signature, true);
+  //   PostLib.Post memory post = createTestPost();
+  //   bytes memory signature = signContentViaWallet(wallet, post);
+  //   spotlight.createPost(post.title, post.content, post.nonce, signature, true);
 
-    address otherUser = vm.addr(2);
-    startHoax(otherUser); // prank, but w/ a balance
-    spotlight.registerProfile("username2");
+  //   address otherUser = vm.addr(2);
+  //   startHoax(otherUser); // prank, but w/ a balance
+  //   spotlight.registerProfile("username2");
 
-    vm.expectEmit();
-    emit PostPurchased(otherUser, signature);
-    spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
-    assertTrue(spotlight.isPurchasePending(signature));
+  //   vm.expectEmit();
+  //   emit PostPurchased(otherUser, signature);
+  //   spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
+  //   assertTrue(spotlight.isPurchasePending(signature));
 
-    vm.expectRevert(PostAlreadyPurchased.selector);
-    spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
-  }
+  //   vm.expectRevert(PostAlreadyPurchased.selector);
+  //   spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
+  // }
 }

--- a/packages/foundry/test/Posts.t.sol
+++ b/packages/foundry/test/Posts.t.sol
@@ -367,88 +367,88 @@ contract PostManagementTest is Test {
     assertEq(comments[1].content, "Second comment.", "Second comment: content mismatch");
   }
 
-  // function testCannotPurchasePostIfPostDoesNotExist() public {
-  //   vm.startPrank(wallet.addr);
-  //   spotlight.registerProfile("username");
+  function testCannotPurchasePostIfPostDoesNotExist() public {
+    startHoax(wallet.addr);
+    spotlight.registerProfile("username");
 
-  //   vm.expectRevert(PostNotFound.selector);
-  //   spotlight.purchasePost("does-not-exist", "pubkey");
-  // }
+    vm.expectRevert(PostNotFound.selector);
+    spotlight.purchasePost{ value: 1 ether }("does-not-exist", "pubkey");
+  }
 
-  // function testCannotPurchasePostIfNotRegistered() public {
-  //   vm.startPrank(wallet.addr);
-  //   spotlight.registerProfile("username");
+  function testCannotPurchasePostIfNotRegistered() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
 
-  //   PostLib.Post memory post = createTestPost();
-  //   bytes memory signature = signContentViaWallet(wallet, post);
-  //   spotlight.createPost(post.title, post.content, post.nonce, signature, true);
-  //   vm.stopPrank();
+    PostLib.Post memory post = createTestPost();
+    bytes memory signature = signContentViaWallet(wallet, post);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, true);
+    vm.stopPrank();
 
-  //   vm.startPrank(vm.addr(2));
-  //   vm.expectRevert(ProfileNotExist.selector);
-  //   spotlight.purchasePost(signature, "pubkey");
-  // }
+    vm.startPrank(vm.addr(2));
+    vm.expectRevert(ProfileNotExist.selector);
+    spotlight.purchasePost(signature, "pubkey");
+  }
 
-  // function testCannotPurchasePostIfPostIsNotPaywalled() public {
-  //   vm.startPrank(wallet.addr);
-  //   spotlight.registerProfile("username");
+  function testCannotPurchasePostIfPostIsNotPaywalled() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
 
-  //   PostLib.Post memory post = createTestPost();
-  //   bytes memory signature = signContentViaWallet(wallet, post);
-  //   spotlight.createPost(post.title, post.content, post.nonce, signature, false);
-  //   vm.stopPrank();
+    PostLib.Post memory post = createTestPost();
+    bytes memory signature = signContentViaWallet(wallet, post);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, false);
+    vm.stopPrank();
 
-  //   address otherUser = vm.addr(2);
-  //   vm.startPrank(otherUser);
-  //   spotlight.registerProfile("username2");
-  //   vm.expectRevert(PostNotPaywalled.selector);
-  //   spotlight.purchasePost(signature, "pubkey");
-  // }
+    address otherUser = vm.addr(2);
+    startHoax(otherUser);
+    spotlight.registerProfile("username2");
+    vm.expectRevert(PostNotPaywalled.selector);
+    spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
+  }
 
-  // function testCreatorCannotPayForTheirOwnContent() public {
-  //   vm.startPrank(wallet.addr);
-  //   spotlight.registerProfile("username");
+  function testCreatorCannotPayForTheirOwnContent() public {
+    startHoax(wallet.addr);
+    spotlight.registerProfile("username");
 
-  //   PostLib.Post memory post = createTestPost();
-  //   bytes memory signature = signContentViaWallet(wallet, post);
-  //   spotlight.createPost(post.title, post.content, post.nonce, signature, true);
-  //   vm.expectRevert(CreatorCannotPayForOwnContent.selector);
-  //   spotlight.purchasePost(signature, "pubkey");
-  // }
+    PostLib.Post memory post = createTestPost();
+    bytes memory signature = signContentViaWallet(wallet, post);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, true);
+    vm.expectRevert(CreatorCannotPayForOwnContent.selector);
+    spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
+  }
 
-  // function testUserCannotPurchasePostWithoutProperFunds() public {
-  //   vm.startPrank(wallet.addr);
-  //   spotlight.registerProfile("username");
+  function testUserCannotPurchasePostWithoutProperFunds() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
 
-  //   PostLib.Post memory post = createTestPost();
-  //   bytes memory signature = signContentViaWallet(wallet, post);
-  //   spotlight.createPost(post.title, post.content, post.nonce, signature, true);
+    PostLib.Post memory post = createTestPost();
+    bytes memory signature = signContentViaWallet(wallet, post);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, true);
 
-  //   address otherUser = vm.addr(2);
-  //   vm.startPrank(otherUser);
-  //   spotlight.registerProfile("username2");
-  //   vm.expectRevert(InsufficentPostFunds.selector);
-  //   spotlight.purchasePost(signature, "pubkey");
-  // }
+    address otherUser = vm.addr(2);
+    vm.startPrank(otherUser);
+    spotlight.registerProfile("username2");
+    vm.expectRevert(InsufficentPostFunds.selector);
+    spotlight.purchasePost(signature, "pubkey");
+  }
 
-  // function testUserCannotDoublePurchaseAPost() public {
-  //   vm.startPrank(wallet.addr);
-  //   spotlight.registerProfile("username");
+  function testUserCannotDoublePurchaseAPost() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
 
-  //   PostLib.Post memory post = createTestPost();
-  //   bytes memory signature = signContentViaWallet(wallet, post);
-  //   spotlight.createPost(post.title, post.content, post.nonce, signature, true);
+    PostLib.Post memory post = createTestPost();
+    bytes memory signature = signContentViaWallet(wallet, post);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, true);
 
-  //   address otherUser = vm.addr(2);
-  //   startHoax(otherUser); // prank, but w/ a balance
-  //   spotlight.registerProfile("username2");
+    address otherUser = vm.addr(2);
+    startHoax(otherUser); // prank, but w/ a balance
+    spotlight.registerProfile("username2");
 
-  //   vm.expectEmit();
-  //   emit PostPurchased(otherUser, signature);
-  //   spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
-  //   assertTrue(spotlight.isPurchasePending(signature));
+    vm.expectEmit();
+    emit PostPurchased(otherUser, signature);
+    spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
+    assertTrue(spotlight.isPurchasePending(signature));
 
-  //   vm.expectRevert(PostAlreadyPurchased.selector);
-  //   spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
-  // }
+    vm.expectRevert(PostAlreadyPurchased.selector);
+    spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
+  }
 }

--- a/packages/foundry/test/Posts.t.sol
+++ b/packages/foundry/test/Posts.t.sol
@@ -9,6 +9,74 @@ import "../contracts/Spotlight.sol";
 import "../contracts/Events.sol";
 import "../contracts/PostLib.sol";
 import "../contracts/Error.sol";
+import "../contracts/Posts.sol";
+
+// Set of tests to validate certain calls can only be made from certain addresses
+contract PostContractCallerValidationTest is Test {
+  function testPostsContractRevertsIfSpotlightAddressIsZero() public {
+    vm.expectRevert(SpotlightAddressCannotBeZero.selector);
+    new Posts(address(0), address(0));
+  }
+
+  function testPostsContractRevertsIfReputationAddressIsZero() public {
+    vm.expectRevert(ReputationAddressCannotBeZero.selector);
+    new Posts(vm.addr(1), address(0));
+  }
+
+  function testNonSpotlightAddrCannotCreatePost() public {
+    Posts pContract = new Posts(vm.addr(1), vm.addr(1));
+    vm.expectRevert(OnlySpotlightCanManagePosts.selector);
+    pContract.createPost(vm.addr(1), "title", "content", 1, "sig", false);
+  }
+
+  function testNonSpotlightAddrCannotEditPost() public {
+    Posts pContract = new Posts(vm.addr(1), vm.addr(1));
+    vm.expectRevert(OnlySpotlightCanManagePosts.selector);
+    pContract.editPost(vm.addr(1), "id", "newContent");
+  }
+
+  function testNonSpotlightAddrCannotDeletePost() public {
+    Posts pContract = new Posts(vm.addr(1), vm.addr(1));
+    vm.expectRevert(OnlySpotlightCanManagePosts.selector);
+    pContract.deletePost(vm.addr(1), "id");
+  }
+
+  function testNonSpotlightAddrCannotDeleteProfile() public {
+    Posts pContract = new Posts(vm.addr(1), vm.addr(1));
+    vm.expectRevert(OnlySpotlightCanManagePosts.selector);
+    pContract.deleteProfile(vm.addr(1));
+  }
+
+  function testNonSpotlightAddrCannotUpvote() public {
+    Posts pContract = new Posts(vm.addr(1), vm.addr(1));
+    vm.expectRevert(OnlySpotlightCanManagePosts.selector);
+    pContract.upvote(vm.addr(1), "id");
+  }
+
+  function testNonSpotlightAddrCannotDownVote() public {
+    Posts pContract = new Posts(vm.addr(1), vm.addr(1));
+    vm.expectRevert(OnlySpotlightCanManagePosts.selector);
+    pContract.downvote(vm.addr(1), "id");
+  }
+
+  function testNonSpotlightAddrCannotAddComment() public {
+    Posts pContract = new Posts(vm.addr(1), vm.addr(1));
+    vm.expectRevert(OnlySpotlightCanManagePosts.selector);
+    pContract.addComment(vm.addr(1), "id", "comment");
+  }
+
+  function testNonSpotlightAddrCannotPurchasePost() public {
+    Posts pContract = new Posts(vm.addr(1), vm.addr(1));
+    vm.expectRevert(OnlySpotlightCanManagePosts.selector);
+    pContract.purchasePost(vm.addr(1), "id", "pubkey");
+  }
+
+  function testNonSpotlightAddrCannotDeclinePurchase() public {
+    Posts pContract = new Posts(vm.addr(1), vm.addr(1));
+    vm.expectRevert(OnlySpotlightCanManagePosts.selector);
+    pContract.declinePurchase(vm.addr(1), "id", payable(vm.addr(1)));
+  }
+}
 
 contract PostManagementTest is Test {
   Spotlight public spotlight;
@@ -341,6 +409,18 @@ contract PostManagementTest is Test {
     assertEq(comments[1].content, "Second comment.", "Second comment: content mismatch");
   }
 
+  function testCannotAddEmptyComment() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
+
+    PostLib.Post memory post = createTestPost();
+    bytes memory signature = signContentViaWallet(wallet, post);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, false);
+
+    vm.expectRevert(CommentCannotBeEmpty.selector);
+    spotlight.addComment(signature, "");
+  }
+
   function testCannotPurchasePostIfPostDoesNotExist() public {
     startHoax(wallet.addr);
     spotlight.registerProfile("username");
@@ -424,5 +504,92 @@ contract PostManagementTest is Test {
 
     vm.expectRevert(PostAlreadyPurchased.selector);
     spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
+  }
+
+  function testCannotDeclinePurchaseIfNotRegistered() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
+
+    PostLib.Post memory post = createTestPost();
+    bytes memory signature = signContentViaWallet(wallet, post);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, true);
+    vm.stopPrank();
+
+    vm.startPrank(vm.addr(2));
+    vm.expectRevert(ProfileNotExist.selector);
+    spotlight.declinePurchase("id", payable(vm.addr(2)));
+  }
+
+  function testCannotDeclinePurchaseIfPostDoesNotExist() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
+
+    vm.expectRevert(PostNotFound.selector);
+    spotlight.declinePurchase("id", payable(wallet.addr));
+  }
+
+  function testOnlyPostCreatorCanDeclinePurchase() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
+
+    PostLib.Post memory post = createTestPost();
+    bytes memory signature = signContentViaWallet(wallet, post);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, true);
+    vm.stopPrank();
+
+    vm.startPrank(vm.addr(2));
+    spotlight.registerProfile("username2");
+    vm.expectRevert(OnlyCreatorCanDeclinePurchase.selector);
+    spotlight.declinePurchase(signature, payable(vm.addr(2)));
+  }
+
+  function testCannotDeclinePurchaseIfPostNotPaywalled() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
+
+    PostLib.Post memory post = createTestPost();
+    bytes memory signature = signContentViaWallet(wallet, post);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, false);
+
+    vm.expectRevert(PostNotPaywalled.selector);
+    spotlight.declinePurchase(signature, payable(vm.addr(2)));
+  }
+
+  function testCannotDeclinePurchaseIfPurchaseNotPending() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
+
+    PostLib.Post memory post = createTestPost();
+    bytes memory signature = signContentViaWallet(wallet, post);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, true);
+
+    vm.expectRevert(NoPendingPurchaseFound.selector);
+    spotlight.declinePurchase(signature, payable(vm.addr(2)));
+  }
+
+  function testFundTransfersWhenCreatorDeclinesPurchase() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
+
+    PostLib.Post memory post = createTestPost();
+    bytes memory signature = signContentViaWallet(wallet, post);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, true);
+
+    address purchaser = vm.addr(2);
+    startHoax(purchaser); // prank, but w/ a balance
+    spotlight.registerProfile("username2");
+
+    // After paying for post, Spotlight holds balance
+    uint256 startingBalance = purchaser.balance;
+    spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
+    assertTrue(spotlight.isPurchasePending(signature));
+    assertEq(startingBalance - spotlight.PAYWALL_COST(), purchaser.balance);
+    assertEq(spotlight.PAYWALL_COST(), address(spotlight).balance);
+    vm.stopPrank();
+
+    // After declining, Spotlight releases balance back to purchaser
+    vm.startPrank(wallet.addr);
+    spotlight.declinePurchase(signature, payable(purchaser));
+    assertEq(startingBalance, purchaser.balance);
   }
 }

--- a/packages/nextjs/components/post/Footer.tsx
+++ b/packages/nextjs/components/post/Footer.tsx
@@ -29,6 +29,8 @@ const PostFooter = ({ post }: { post: TPost }) => {
     functionName: "downvotedBy",
     args: [post.signature, address],
   });
+  console.log("hasUpvoted", hasUpvoted);
+  console.log("hasDownvoted", hasDownvoted);
 
   const onUpvoteClick = async (evt: React.MouseEvent<HTMLAnchorElement>) => {
     evt.stopPropagation();

--- a/packages/nextjs/components/post/PendingPurchase.tsx
+++ b/packages/nextjs/components/post/PendingPurchase.tsx
@@ -1,10 +1,10 @@
 import { encrypt } from "@metamask/eth-sig-util";
 import { toHex } from "viem";
-// import { useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
+import { useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 import { TPendingPurchase, TPost } from "~~/types/spotlight";
 
 const PendingPurchase = ({ post, pendingPurchase }: { post: TPost; pendingPurchase: TPendingPurchase }) => {
-  // const { writeContractAsync: writeSpotlightContractAsync } = useScaffoldWriteContract("Spotlight");
+  const { writeContractAsync: writeSpotlightContractAsync } = useScaffoldWriteContract("Spotlight");
 
   const acceptPurchase = async () => {
     const decryptedContent = await window.ethereum.request({
@@ -23,10 +23,10 @@ const PendingPurchase = ({ post, pendingPurchase }: { post: TPost; pendingPurcha
 
   const decline = async () => {
     console.log("call declinePurchase contract method");
-    // await writeSpotlightContractAsync({
-    //   functionName: "declinePurchase",
-    //   args: [post.id, pendingPurchase.purchaser],
-    // });
+    await writeSpotlightContractAsync({
+      functionName: "declinePurchase",
+      args: [post.id, pendingPurchase.purchaser],
+    });
   };
 
   const shortendAddr =

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -7,7 +7,7 @@ import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 const deployedContracts = {
   31337: {
     Spotlight: {
-      address: "0x5fbdb2315678afecb367f032d93f642f64180aa3",
+      address: "0x0b306bf915c4d645ff596e518faf3f9669b97016",
       abi: [
         {
           type: "constructor",
@@ -86,6 +86,24 @@ const deployedContracts = {
         },
         {
           type: "function",
+          name: "declinePurchase",
+          inputs: [
+            {
+              name: "_id",
+              type: "bytes",
+              internalType: "bytes",
+            },
+            {
+              name: "purchaser",
+              type: "address",
+              internalType: "address payable",
+            },
+          ],
+          outputs: [],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
           name: "deletePost",
           inputs: [
             {
@@ -122,12 +140,12 @@ const deployedContracts = {
           name: "downvotedBy",
           inputs: [
             {
-              name: "",
+              name: "_id",
               type: "bytes",
               internalType: "bytes",
             },
             {
-              name: "",
+              name: "_addr",
               type: "address",
               internalType: "address",
             },
@@ -273,7 +291,7 @@ const deployedContracts = {
             {
               name: "",
               type: "tuple[]",
-              internalType: "struct Spotlight.PendingPurchase[]",
+              internalType: "struct Posts.PendingPurchase[]",
               components: [
                 {
                   name: "purchaser",
@@ -609,12 +627,12 @@ const deployedContracts = {
           name: "upvotedBy",
           inputs: [
             {
-              name: "",
+              name: "_id",
               type: "bytes",
               internalType: "bytes",
             },
             {
-              name: "",
+              name: "_addr",
               type: "address",
               internalType: "address",
             },
@@ -836,42 +854,7 @@ const deployedContracts = {
         },
         {
           type: "error",
-          name: "ContentCannotBeEmpty",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "CreatorCannotPayForOwnContent",
-          inputs: [],
-        },
-        {
-          type: "error",
           name: "InsufficentPostFunds",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "InvalidSignature",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "OnlyCreatorCanEdit",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "PostAlreadyPurchased",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "PostNotFound",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "PostNotPaywalled",
           inputs: [],
         },
         {
@@ -887,11 +870,6 @@ const deployedContracts = {
         {
           type: "error",
           name: "ReentrancyGuardReentrantCall",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "TitleCannotBeEmpty",
           inputs: [],
         },
         {
@@ -994,6 +972,24 @@ const deployedContracts = {
         },
         {
           type: "function",
+          name: "declinePurchase",
+          inputs: [
+            {
+              name: "_id",
+              type: "bytes",
+              internalType: "bytes",
+            },
+            {
+              name: "purchaser",
+              type: "address",
+              internalType: "address payable",
+            },
+          ],
+          outputs: [],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
           name: "deletePost",
           inputs: [
             {
@@ -1030,12 +1026,12 @@ const deployedContracts = {
           name: "downvotedBy",
           inputs: [
             {
-              name: "",
+              name: "_id",
               type: "bytes",
               internalType: "bytes",
             },
             {
-              name: "",
+              name: "_addr",
               type: "address",
               internalType: "address",
             },
@@ -1181,7 +1177,7 @@ const deployedContracts = {
             {
               name: "",
               type: "tuple[]",
-              internalType: "struct Spotlight.PendingPurchase[]",
+              internalType: "struct Posts.PendingPurchase[]",
               components: [
                 {
                   name: "purchaser",
@@ -1517,12 +1513,12 @@ const deployedContracts = {
           name: "upvotedBy",
           inputs: [
             {
-              name: "",
+              name: "_id",
               type: "bytes",
               internalType: "bytes",
             },
             {
-              name: "",
+              name: "_addr",
               type: "address",
               internalType: "address",
             },
@@ -1744,42 +1740,7 @@ const deployedContracts = {
         },
         {
           type: "error",
-          name: "ContentCannotBeEmpty",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "CreatorCannotPayForOwnContent",
-          inputs: [],
-        },
-        {
-          type: "error",
           name: "InsufficentPostFunds",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "InvalidSignature",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "OnlyCreatorCanEdit",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "PostAlreadyPurchased",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "PostNotFound",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "PostNotPaywalled",
           inputs: [],
         },
         {
@@ -1795,11 +1756,6 @@ const deployedContracts = {
         {
           type: "error",
           name: "ReentrancyGuardReentrantCall",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "TitleCannotBeEmpty",
           inputs: [],
         },
         {


### PR DESCRIPTION
### Changes
* Create `Posts` contract that is initialized, just like `Reputation`
* Make `Reputation` contract aware of `Posts` contract - this allows the `Posts` contract to mint/burn RPT on up/downvotes
* Addition: creator can decline payment for a post, which issues a refund :tada: 

### Contract size breakdown

Before - just barely under the 24KB mark under `Runtime Size`
```
| Contract         | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
|------------------|------------------|-------------------|--------------------|---------------------|
| BytesLib         |               86 |               141 |             24,490 |              49,011 |
| ECDSA            |               86 |               141 |             24,490 |              49,011 |
| Math             |               86 |               141 |             24,490 |              49,011 |
| MessageHashUtils |               86 |               141 |             24,490 |              49,011 |
| PostLib          |               86 |               141 |             24,490 |              49,011 |
| Reputation       |            3,851 |             4,514 |             20,725 |              44,638 |
| SignatureChecker |               86 |               141 |             24,490 |              49,011 |
| SignedMath       |               86 |               141 |             24,490 |              49,011 |
| Spotlight        |           23,769 |            28,535 |                807 |              20,617 |
| Strings          |               86 |               141 |             24,490 |              49,011 |
```

After - :tada: 
```
| Contract         | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
|------------------|------------------|-------------------|--------------------|---------------------|
| BytesLib         |               86 |               141 |             24,490 |              49,011 |
| ECDSA            |               86 |               141 |             24,490 |              49,011 |
| Math             |               86 |               141 |             24,490 |              49,011 |
| MessageHashUtils |               86 |               141 |             24,490 |              49,011 |
| PostLib          |               86 |               141 |             24,490 |              49,011 |
| Posts            |           15,542 |            15,837 |              9,034 |              33,315 |
| Reputation       |            3,922 |             4,557 |             20,654 |              44,595 |
| SignatureChecker |               86 |               141 |             24,490 |              49,011 |
| SignedMath       |               86 |               141 |             24,490 |              49,011 |
| Spotlight        |           10,467 |            31,310 |             14,109 |              17,842 |
| Strings          |               86 |               141 |             24,490 |              49,011 |
```