### PR TITLE
Paywall settlement

### DIFF
--- a/packages/foundry/contracts/Error.sol
+++ b/packages/foundry/contracts/Error.sol
@@ -57,3 +57,5 @@ error CommentCannotBeEmpty();
 error OnlyCreatorCanDeclinePurchase();
 
 error NoPendingPurchaseFound();
+
+error OnlyCreatorCanAcceptPurchase();

--- a/packages/foundry/contracts/Posts.sol
+++ b/packages/foundry/contracts/Posts.sol
@@ -331,4 +331,8 @@ contract Posts {
     }
     delete purchaserPublicKeys[_id][_purchaser];
   }
+
+  function getPurchasedPost(address _addr, bytes calldata _id) public view returns (PostLib.Post memory) {
+    return purchasedPosts[_addr][_id];
+  }
 }

--- a/packages/foundry/contracts/Posts.sol
+++ b/packages/foundry/contracts/Posts.sol
@@ -48,6 +48,9 @@ contract Posts {
   // Map of creator address => list of (users + posts) have they paid for?
   mapping(address => PendingPurchase[]) internal pendingPurchases;
 
+  /// @dev Mapping of purchaser address => map of purchased Posts
+  mapping(address => mapping(bytes => PostLib.Post)) purchasedPosts;
+
   constructor(address _spotlightContract, address _reputationContract) {
     if (_spotlightContract == address(0)) revert SpotlightAddressCannotBeZero();
     if (_reputationContract == address(0)) revert ReputationAddressCannotBeZero();
@@ -282,20 +285,50 @@ contract Posts {
     return pendingPurchases[_addr];
   }
 
-  function declinePurchase(address _addr, bytes calldata _id, address payable purchaser) public {
+  function declinePurchase(address _creator, bytes calldata _id, address _purchaser) public {
+    purchaseSettlementValidations(_id, _purchaser);
+    // TODO: Purchaser is allowed to decline the purchase!
+    if (postStore[_id].creator != _creator) revert OnlyCreatorCanDeclinePurchase();
+    removePurchaseFromPending(_creator, _id, _purchaser);
+  }
+
+  function acceptPurchase(address _creator, bytes calldata _id, address _purchaser, string memory _content) public {
+    purchaseSettlementValidations(_id, _purchaser);
+    PostLib.Post memory p = postStore[_id];
+    if (p.creator != _creator) revert OnlyCreatorCanAcceptPurchase();
+
+    // Create a copy of the post for the purchaser - content is encrypted with their pubkey
+    purchasedPosts[_purchaser][_id] = PostLib.Post({
+      creator: p.creator,
+      title: p.title,
+      content: _content,
+      id: _id,
+      signature: p.signature,
+      nonce: p.nonce,
+      paywalled: true,
+      createdAt: p.createdAt,
+      lastUpdatedAt: p.lastUpdatedAt,
+      upvoteCount: 0, // This won't actually apply
+      downvoteCount: 0 // This won't actually apply
+     });
+    removePurchaseFromPending(_creator, _id, _purchaser);
+  }
+
+  function purchaseSettlementValidations(bytes calldata _id, address _purchaser) internal view {
     if (msg.sender != spotlightContract) revert OnlySpotlightCanManagePosts();
     checkPostExists(_id);
-    if (postStore[_id].creator != _addr) revert OnlyCreatorCanDeclinePurchase();
     if (!postStore[_id].paywalled) revert PostNotPaywalled();
-    if (!isPurchasePending(purchaser, _id)) revert NoPendingPurchaseFound();
+    if (!isPurchasePending(_purchaser, _id)) revert NoPendingPurchaseFound();
+  }
 
-    for (uint256 i = 0; i < pendingPurchases[_addr].length; i++) {
-      if (keccak256(pendingPurchases[_addr][i].postId) == keccak256(_id)) {
-        pendingPurchases[_addr][i] = pendingPurchases[_addr][pendingPurchases[_addr].length - 1];
-        pendingPurchases[_addr].pop();
+  function removePurchaseFromPending(address _creator, bytes calldata _id, address _purchaser) internal {
+    for (uint256 i = 0; i < pendingPurchases[_creator].length; i++) {
+      if (keccak256(pendingPurchases[_creator][i].postId) == keccak256(_id)) {
+        pendingPurchases[_creator][i] = pendingPurchases[_creator][pendingPurchases[_creator].length - 1];
+        pendingPurchases[_creator].pop();
         break;
       }
     }
-    delete purchaserPublicKeys[_id][purchaser];
+    delete purchaserPublicKeys[_id][_purchaser];
   }
 }

--- a/packages/foundry/contracts/Spotlight.sol
+++ b/packages/foundry/contracts/Spotlight.sol
@@ -264,9 +264,19 @@ contract Spotlight is ReentrancyGuard {
     return postsContract.getPendingPurchases(msg.sender);
   }
 
-  function declinePurchase(bytes calldata _id, address payable purchaser) public onlyRegistered nonReentrant {
-    postsContract.declinePurchase(msg.sender, _id, purchaser);
+  function declinePurchase(bytes calldata _id, address payable _purchaser) public onlyRegistered nonReentrant {
+    postsContract.declinePurchase(msg.sender, _id, _purchaser);
     // TODO: Make sure the contract has the funds to handle the refund of the decline
-    purchaser.transfer(0.1 ether);
+    _purchaser.transfer(PAYWALL_COST);
+  }
+
+  function acceptPurchase(bytes calldata _id, address payable _purchaser, string memory _content)
+    public
+    onlyRegistered
+    nonReentrant
+  {
+    postsContract.acceptPurchase(msg.sender, _id, _purchaser, _content);
+    // TODO: Make sure the contract has the funds to handle the refund of the decline
+    payable(msg.sender).transfer(PAYWALL_COST);
   }
 }

--- a/packages/foundry/contracts/Spotlight.sol
+++ b/packages/foundry/contracts/Spotlight.sol
@@ -270,7 +270,7 @@ contract Spotlight is ReentrancyGuard {
     _purchaser.transfer(PAYWALL_COST);
   }
 
-  function acceptPurchase(bytes calldata _id, address payable _purchaser, string memory _content)
+  function acceptPurchase(bytes calldata _id, address _purchaser, string memory _content)
     public
     onlyRegistered
     nonReentrant
@@ -278,5 +278,9 @@ contract Spotlight is ReentrancyGuard {
     postsContract.acceptPurchase(msg.sender, _id, _purchaser, _content);
     // TODO: Make sure the contract has the funds to handle the refund of the decline
     payable(msg.sender).transfer(PAYWALL_COST);
+  }
+
+  function getPurchasedPost(bytes calldata _id) public view returns (PostLib.Post memory) {
+    return postsContract.getPurchasedPost(msg.sender, _id);
   }
 }

--- a/packages/foundry/test/Posts.t.sol
+++ b/packages/foundry/test/Posts.t.sol
@@ -537,8 +537,14 @@ contract PostManagementTest is Test {
     spotlight.createPost(post.title, post.content, post.nonce, signature, true);
     vm.stopPrank();
 
-    vm.startPrank(vm.addr(2));
+    address purchaser = vm.addr(2);
+    startHoax(purchaser); // prank, but w/ a balance
     spotlight.registerProfile("username2");
+    spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
+    vm.stopPrank();
+
+    vm.startPrank(vm.addr(3));
+    spotlight.registerProfile("username3");
     vm.expectRevert(OnlyCreatorCanDeclinePurchase.selector);
     spotlight.declinePurchase(signature, payable(vm.addr(2)));
   }

--- a/packages/foundry/test/Posts.t.sol
+++ b/packages/foundry/test/Posts.t.sol
@@ -597,5 +597,66 @@ contract PostManagementTest is Test {
     vm.startPrank(wallet.addr);
     spotlight.declinePurchase(signature, payable(purchaser));
     assertEq(startingBalance, purchaser.balance);
+    vm.stopPrank();
+
+    vm.startPrank(purchaser);
+    assertFalse(spotlight.isPurchasePending(signature));
+  }
+
+  function testCreatorCanRetrievePendingPurchases() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
+
+    PostLib.Post memory post = createTestPost();
+    bytes memory signature = signContentViaWallet(wallet, post);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, true);
+
+    address purchaser = vm.addr(2);
+    startHoax(purchaser); // prank, but w/ a balance
+    spotlight.registerProfile("username2");
+    spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
+    vm.stopPrank;
+
+    vm.startPrank(wallet.addr);
+    Posts.PendingPurchase[] memory pending = spotlight.getPendingPurchases();
+    assertEq(1, pending.length);
+    assertEq(purchaser, pending[0].purchaser);
+    assertEq(signature, pending[0].postId);
+    assertEq("pubkey", pending[0].pubkey);
+  }
+
+  function testFundTransferAndPostCopyWhenCreatorAcceptsPurchase() public {
+    vm.startPrank(wallet.addr);
+    spotlight.registerProfile("username");
+
+    PostLib.Post memory post = createTestPost();
+    bytes memory signature = signContentViaWallet(wallet, post);
+    spotlight.createPost(post.title, post.content, post.nonce, signature, true);
+
+    address purchaser = vm.addr(2);
+    startHoax(purchaser); // prank, but w/ a balance
+    spotlight.registerProfile("username2");
+    spotlight.purchasePost{ value: 1 ether }(signature, "pubkey");
+    vm.stopPrank();
+
+    // After accepting, Spotlight releases balance to creator
+    vm.startPrank(wallet.addr);
+    spotlight.acceptPurchase(signature, purchaser, "newly-encrypted-content-for-you");
+    assertEq(spotlight.PAYWALL_COST(), wallet.addr.balance);
+    assertEq(0, address(spotlight).balance);
+    vm.stopPrank();
+
+    vm.startPrank(purchaser);
+    PostLib.Post memory purchasedPost = spotlight.getPurchasedPost(signature);
+    assertEq(wallet.addr, purchasedPost.creator);
+    assertEq(post.title, purchasedPost.title);
+    assertEq("newly-encrypted-content-for-you", purchasedPost.content);
+    assertEq(signature, purchasedPost.id);
+    assertEq(signature, purchasedPost.signature);
+    assertEq(post.nonce, purchasedPost.nonce);
+    assertTrue(purchasedPost.paywalled);
+
+    // Now that the purchase was settled, it should no longer be pending
+    assertFalse(spotlight.isPurchasePending(signature));
   }
 }

--- a/packages/nextjs/app/feed/createPost.tsx
+++ b/packages/nextjs/app/feed/createPost.tsx
@@ -63,16 +63,6 @@ const CreatePage: NextPage = () => {
           functionName: "createPost",
           args: [title, strEncryptedPost, nonce, postSig, paywalled],
         });
-
-        // EXAMPLE DECRYPTION
-        // import { decrypt } from "@metamask/eth-sig-util";
-        // sleep for 500ms - metamask gets unhappy if you spam it with back-2-back reqs
-        // await new Promise(f => setTimeout(f, 500));
-        // const x = await window.ethereum.request({
-        //   method: "eth_decrypt",
-        //   params: [`0x${Buffer.from(JSON.stringify(encryptedPost), "utf8").toString("hex")}`, address],
-        // });
-        // console.log(x);
       } else {
         // TODO: work on this duplication... bleh
         const postSig = await createPostSignature({ signMessageAsync, title, content, nonce });

--- a/packages/nextjs/app/feed/page.tsx
+++ b/packages/nextjs/app/feed/page.tsx
@@ -18,7 +18,7 @@ const FeedPage: NextPage = () => {
       // They need to go register first...
       router.push("/");
     }
-  });
+  }, [userProfile, router]);
 
   if (userProfile === undefined) {
     // We cannot render anything

--- a/packages/nextjs/app/feed/viewPost/page.tsx
+++ b/packages/nextjs/app/feed/viewPost/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { useContext, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import FeedHeaderPage from "../header";
 import BackButton from "./BackButton";
 import Comments from "./comments";
@@ -9,14 +9,23 @@ import type { NextPage } from "next";
 import { Hex } from "viem";
 import Post from "~~/components/post/Post";
 import { PostDeleteContext, PostDisplayContext, PostEditContext } from "~~/contexts/Post";
+import { UserProfileContext } from "~~/contexts/UserProfile";
 
 const ViewPostPage: NextPage = () => {
+  const router = useRouter();
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [editing, setEditing] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const searchParams = useSearchParams();
   const postSig = searchParams?.get("postSig") || "";
+  const { userProfile } = useContext(UserProfileContext);
+  useEffect(() => {
+    if (userProfile && userProfile.username === "") {
+      // They need to go register first...
+      router.push("/");
+    }
+  }, [userProfile, router]);
 
   if (!postSig) {
     return <div>Loading...</div>; // Handle case where postSig is not yet available

--- a/packages/nextjs/components/post/DeleteModal.tsx
+++ b/packages/nextjs/components/post/DeleteModal.tsx
@@ -28,7 +28,7 @@ const PostDeleteModal = ({ post }: { post: TPost }) => {
   return (
     showDeleteConfirmation && (
       <>
-        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-10">
           <div className="bg-white p-6 rounded shadow-lg text-center">
             <p>Are you sure you want to delete this post?</p>
             <div className="mt-4 flex justify-center gap-4">

--- a/packages/nextjs/components/post/Footer.tsx
+++ b/packages/nextjs/components/post/Footer.tsx
@@ -29,8 +29,6 @@ const PostFooter = ({ post }: { post: TPost }) => {
     functionName: "downvotedBy",
     args: [post.signature, address],
   });
-  console.log("hasUpvoted", hasUpvoted);
-  console.log("hasDownvoted", hasDownvoted);
 
   const onUpvoteClick = async (evt: React.MouseEvent<HTMLAnchorElement>) => {
     evt.stopPropagation();

--- a/packages/nextjs/components/post/PaywallMessage.tsx
+++ b/packages/nextjs/components/post/PaywallMessage.tsx
@@ -5,29 +5,44 @@ const PaywallMessage = ({
   post,
   paywallSupported,
   purchasePending,
+  purchasedPost,
 }: {
   post: TPost;
   paywallSupported: boolean;
-  purchasePending: boolean | undefined;
+  purchasePending: boolean;
+  purchasedPost: TPost;
 }) => {
   const { address } = useAccount();
 
+  const showPaywalMsg = () => {
+    const unsupportedMsg = `This post is currently paywalled, but you are using a wallet \
+      that does not support the required features to engage with our \
+      payment procotol.`;
+    const purchasePendingMsg = "You have purchased this post. Please wait for review by it's creator.";
+    const purchaseMsg = "Please click the unlock icon to purchase this post from it's creator.";
+    const creatorMsg = "Click the unlock button to decrypt your post.";
+    const purchasedMsg = (
+      <>
+        You have purchased this post and it is available for viewing.
+        <br />
+        Click the unlock button to decrypt your post.
+      </>
+    );
+
+    if (!paywallSupported) return unsupportedMsg;
+    if (post.creator == address) return creatorMsg;
+    if (purchasedPost.content.length > 0) return purchasedMsg;
+    if (purchasePending) return purchasePendingMsg;
+    return purchaseMsg;
+  };
+
   const trimId = post.id.substring(0, 6) + "..." + post.id.substring(post.id.length - 4);
-  const unsupportedMsg = `This post is currently paywalled, but you are using a wallet \
-    that does not support the required features to engage with our \
-    payment procotol.`;
-  const purchasePendingMsg = "You have purchased this post. Please wait for review by it's creator.";
-  const purchaseMsg = "Please click the unlock icon to purchase this post from it's creator.";
-  const creatorMsg = "Click the unlock button to decrypt your post.";
 
   return (
     <>
       <div className="italic">
         <div>{trimId} is paywalled.</div>
-        {!paywallSupported && unsupportedMsg}
-        {paywallSupported && post.creator != address && purchasePending && purchasePendingMsg}
-        {paywallSupported && post.creator != address && !purchasePending && purchaseMsg}
-        {paywallSupported && post.creator == address && creatorMsg}
+        <div>{showPaywalMsg()}</div>
       </div>
     </>
   );

--- a/packages/nextjs/components/post/PendingPurchase.tsx
+++ b/packages/nextjs/components/post/PendingPurchase.tsx
@@ -28,11 +28,12 @@ const PendingPurchase = ({ post, pendingPurchase }: { post: TPost; pendingPurcha
       });
 
       console.log(encryptedForPurchaser);
-      // await new Promise(f => setTimeout(f, 500));
-      // await writeSpotlightContractAsync({
-      //   functionName: "acceptPurchase",
-      //   args: [post.id, pendingPurchase.purchaser]
-      // });
+      const strEncryptedPost = JSON.stringify(encryptedForPurchaser);
+      await new Promise(f => setTimeout(f, 500));
+      await writeSpotlightContractAsync({
+        functionName: "acceptPurchase",
+        args: [post.id, pendingPurchase.purchaser, strEncryptedPost],
+      });
     } catch (e: any) {
       console.log(e);
       notification.error("Could not accept purchase!");

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -7,7 +7,7 @@ import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 const deployedContracts = {
   31337: {
     Spotlight: {
-      address: "0x0b306bf915c4d645ff596e518faf3f9669b97016",
+      address: "0x959922be3caee4b8cd9a407cc3ac1c251c2007b1",
       abi: [
         {
           type: "constructor",
@@ -32,6 +32,29 @@ const deployedContracts = {
             },
           ],
           stateMutability: "view",
+        },
+        {
+          type: "function",
+          name: "acceptPurchase",
+          inputs: [
+            {
+              name: "_id",
+              type: "bytes",
+              internalType: "bytes",
+            },
+            {
+              name: "_purchaser",
+              type: "address",
+              internalType: "address",
+            },
+            {
+              name: "_content",
+              type: "string",
+              internalType: "string",
+            },
+          ],
+          outputs: [],
+          stateMutability: "nonpayable",
         },
         {
           type: "function",
@@ -94,7 +117,7 @@ const deployedContracts = {
               internalType: "bytes",
             },
             {
-              name: "purchaser",
+              name: "_purchaser",
               type: "address",
               internalType: "address payable",
             },
@@ -493,6 +516,82 @@ const deployedContracts = {
                 },
                 {
                   name: "reputation",
+                  type: "uint256",
+                  internalType: "uint256",
+                },
+              ],
+            },
+          ],
+          stateMutability: "view",
+        },
+        {
+          type: "function",
+          name: "getPurchasedPost",
+          inputs: [
+            {
+              name: "_id",
+              type: "bytes",
+              internalType: "bytes",
+            },
+          ],
+          outputs: [
+            {
+              name: "",
+              type: "tuple",
+              internalType: "struct PostLib.Post",
+              components: [
+                {
+                  name: "creator",
+                  type: "address",
+                  internalType: "address",
+                },
+                {
+                  name: "title",
+                  type: "string",
+                  internalType: "string",
+                },
+                {
+                  name: "content",
+                  type: "string",
+                  internalType: "string",
+                },
+                {
+                  name: "id",
+                  type: "bytes",
+                  internalType: "bytes",
+                },
+                {
+                  name: "signature",
+                  type: "bytes",
+                  internalType: "bytes",
+                },
+                {
+                  name: "paywalled",
+                  type: "bool",
+                  internalType: "bool",
+                },
+                {
+                  name: "nonce",
+                  type: "uint256",
+                  internalType: "uint256",
+                },
+                {
+                  name: "createdAt",
+                  type: "uint256",
+                  internalType: "uint256",
+                },
+                {
+                  name: "lastUpdatedAt",
+                  type: "uint256",
+                  internalType: "uint256",
+                },
+                {
+                  name: "upvoteCount",
+                  type: "uint256",
+                  internalType: "uint256",
+                },
+                {
+                  name: "downvoteCount",
                   type: "uint256",
                   internalType: "uint256",
                 },
@@ -921,6 +1020,29 @@ const deployedContracts = {
         },
         {
           type: "function",
+          name: "acceptPurchase",
+          inputs: [
+            {
+              name: "_id",
+              type: "bytes",
+              internalType: "bytes",
+            },
+            {
+              name: "_purchaser",
+              type: "address",
+              internalType: "address",
+            },
+            {
+              name: "_content",
+              type: "string",
+              internalType: "string",
+            },
+          ],
+          outputs: [],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
           name: "addComment",
           inputs: [
             {
@@ -980,7 +1102,7 @@ const deployedContracts = {
               internalType: "bytes",
             },
             {
-              name: "purchaser",
+              name: "_purchaser",
               type: "address",
               internalType: "address payable",
             },
@@ -1379,6 +1501,82 @@ const deployedContracts = {
                 },
                 {
                   name: "reputation",
+                  type: "uint256",
+                  internalType: "uint256",
+                },
+              ],
+            },
+          ],
+          stateMutability: "view",
+        },
+        {
+          type: "function",
+          name: "getPurchasedPost",
+          inputs: [
+            {
+              name: "_id",
+              type: "bytes",
+              internalType: "bytes",
+            },
+          ],
+          outputs: [
+            {
+              name: "",
+              type: "tuple",
+              internalType: "struct PostLib.Post",
+              components: [
+                {
+                  name: "creator",
+                  type: "address",
+                  internalType: "address",
+                },
+                {
+                  name: "title",
+                  type: "string",
+                  internalType: "string",
+                },
+                {
+                  name: "content",
+                  type: "string",
+                  internalType: "string",
+                },
+                {
+                  name: "id",
+                  type: "bytes",
+                  internalType: "bytes",
+                },
+                {
+                  name: "signature",
+                  type: "bytes",
+                  internalType: "bytes",
+                },
+                {
+                  name: "paywalled",
+                  type: "bool",
+                  internalType: "bool",
+                },
+                {
+                  name: "nonce",
+                  type: "uint256",
+                  internalType: "uint256",
+                },
+                {
+                  name: "createdAt",
+                  type: "uint256",
+                  internalType: "uint256",
+                },
+                {
+                  name: "lastUpdatedAt",
+                  type: "uint256",
+                  internalType: "uint256",
+                },
+                {
+                  name: "upvoteCount",
+                  type: "uint256",
+                  internalType: "uint256",
+                },
+                {
+                  name: "downvoteCount",
                   type: "uint256",
                   internalType: "uint256",
                 },


### PR DESCRIPTION
### Contract updates
* `Posts` contract now tracks `purchasedPosts`: a mapping of a user's wallet => mapping of a post ID to a Post they purchased
* Contracts now support an `acceptPurchase` method which
  * Transfers funds to the creator
  * Creates a copy of the post and stores it in the `purchasedPosts` mapping, keyed by the purchaser's address - but with the provided `content` argument. This is the the content of the post encrypted with the purchaser's public key
* Contracts additionally support `getPurchasedPost` - allowing a user to retrieve a post that a creator accepted payment for.
* Unit tests

### UI updates
* When a creator accepts a purchase
  * The UI decrypts the post with their private key
  * The UI re-encrypts the post with the public key of the purchaser
  * The UI calls the `acceptPurchase` contract method, providing the re-encrypted content of the post, which only the purchaser will be able to decrypt

### Extras
* Clean up the paywall messaging - it was getting unruly doing all the conditionals within the JSX rendering :grimacing: 
* Set a z-index for delete modal - the "Managing pending purchases" component was interfering with it.
* `viewPost` page now redirects to signup page if the user is not registered yet.

### Contract sizes
```$ yarn compile --sizes
[⠢] Compiling...
No files changed, compilation skipped
| Contract         | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
|------------------|------------------|-------------------|--------------------|---------------------|
| BytesLib         |               86 |               166 |             24,490 |              48,986 |
| ECDSA            |               86 |               166 |             24,490 |              48,986 |
| Math             |               86 |               166 |             24,490 |              48,986 |
| MessageHashUtils |               86 |               166 |             24,490 |              48,986 |
| PostLib          |               86 |               166 |             24,490 |              48,986 |
| Posts            |           17,864 |            18,198 |              6,712 |              30,954 |
| Reputation       |            3,922 |             4,557 |             20,654 |              44,595 |
| SignatureChecker |               86 |               166 |             24,490 |              48,986 |
| SignedMath       |               86 |               166 |             24,490 |              48,986 |
| Spotlight        |           11,172 |            34,376 |             13,404 |              14,776 |
| Strings          |               86 |               166 |             24,490 |              48,986 |
```