### PR TITLE
Allow a purchaser to cancel their purchase

### DIFF
--- a/packages/foundry/contracts/Events.sol
+++ b/packages/foundry/contracts/Events.sol
@@ -53,3 +53,5 @@ event TokenBurned(address indexed account, uint256 amount);
 event CommentAdded(address indexed commenter, bytes indexed postId, string content, uint256 createdAt);
 
 event PostPurchased(address indexed purchaser, bytes indexed postId);
+
+event RPTContractCreated(address indexed rptAddress);

--- a/packages/foundry/contracts/Events.sol
+++ b/packages/foundry/contracts/Events.sol
@@ -53,5 +53,3 @@ event TokenBurned(address indexed account, uint256 amount);
 event CommentAdded(address indexed commenter, bytes indexed postId, string content, uint256 createdAt);
 
 event PostPurchased(address indexed purchaser, bytes indexed postId);
-
-event RPTContractCreated(address indexed rptAddress);

--- a/packages/foundry/contracts/Posts.sol
+++ b/packages/foundry/contracts/Posts.sol
@@ -285,11 +285,13 @@ contract Posts {
     return pendingPurchases[_addr];
   }
 
-  function declinePurchase(address _creator, bytes calldata _id, address _purchaser) public {
+  function declinePurchase(address _decliner, bytes calldata _id, address _purchaser) public {
     purchaseSettlementValidations(_id, _purchaser);
-    // TODO: Purchaser is allowed to decline the purchase!
-    if (postStore[_id].creator != _creator) revert SpotlightErrors.OnlyCreatorCanDeclinePurchase();
-    removePurchaseFromPending(_creator, _id, _purchaser);
+    if (postStore[_id].creator == _decliner || _decliner == _purchaser) {
+      removePurchaseFromPending(postStore[_id].creator, _id, _purchaser);
+    } else {
+      revert SpotlightErrors.OnlyCreatorOrPurchaserCanDeclinePurchase();
+    }
   }
 
   function acceptPurchase(address _creator, bytes calldata _id, address _purchaser, string memory _content) public {

--- a/packages/foundry/contracts/Reputation.sol
+++ b/packages/foundry/contracts/Reputation.sol
@@ -6,15 +6,17 @@ import "./Events.sol";
 import "./SpotlightErrors.sol";
 
 contract Reputation is ERC20 {
-  address public immutable spotlightContract;
+  address public spotlightContract;
   address private postsContract;
   uint256 private constant DECAY_INTERVAL = 15 minutes;
   uint256 private constant DECAY_RATE = 1; // 1% decay every 15 minutes
   mapping(address => uint256) private lastDecayTime;
 
-  constructor(address _spotlightContract) ERC20("Reputation", "RPT") {
-    if (_spotlightContract == address(0)) revert SpotlightErrors.SpotlightAddressCannotBeZero();
-    spotlightContract = _spotlightContract;
+  constructor() ERC20("Reputation", "RPT") { }
+
+  function setSpotlightContract(address _addr) public {
+    if (_addr == address(0)) revert SpotlightErrors.SpotlightAddressCannotBeZero();
+    spotlightContract = _addr;
   }
 
   function setPostsContract(address _addr) public {

--- a/packages/foundry/contracts/Spotlight.sol
+++ b/packages/foundry/contracts/Spotlight.sol
@@ -49,14 +49,12 @@ contract Spotlight is ReentrancyGuard, SpotlightErrors {
 
   /// @notice Constructor sets the contract owner during deployment.
   /// @param _owner The address of the owner.
-  constructor(address _owner) {
+  constructor(address _owner, address _rtpContract) {
     owner = _owner;
-    reputationToken = new Reputation(address(this));
-    postsContract = new Posts(address(this), address(reputationToken));
+    reputationToken = Reputation(_rtpContract);
+    postsContract = new Posts(address(this), _rtpContract);
+    reputationToken.setSpotlightContract(address(this));
     reputationToken.setPostsContract(address(postsContract));
-
-    // Make it easier to locate the contract address for importing into wallets
-    emit RPTContractCreated(address(reputationToken));
   }
 
   /// @notice Modifier to ensure that only registered users can perform certain actions.

--- a/packages/foundry/contracts/Spotlight.sol
+++ b/packages/foundry/contracts/Spotlight.sol
@@ -54,6 +54,9 @@ contract Spotlight is ReentrancyGuard, SpotlightErrors {
     reputationToken = new Reputation(address(this));
     postsContract = new Posts(address(this), address(reputationToken));
     reputationToken.setPostsContract(address(postsContract));
+
+    // Make it easier to locate the contract address for importing into wallets
+    emit RPTContractCreated(address(reputationToken));
   }
 
   /// @notice Modifier to ensure that only registered users can perform certain actions.

--- a/packages/foundry/contracts/SpotlightErrors.sol
+++ b/packages/foundry/contracts/SpotlightErrors.sol
@@ -55,7 +55,7 @@ contract SpotlightErrors {
 
   error CommentCannotBeEmpty();
 
-  error OnlyCreatorCanDeclinePurchase();
+  error OnlyCreatorOrPurchaserCanDeclinePurchase();
 
   error NoPendingPurchaseFound();
 

--- a/packages/foundry/script/Deploy.s.sol
+++ b/packages/foundry/script/Deploy.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.19;
 
 import "../contracts/Spotlight.sol";
+import "../contracts/Reputation.sol";
 import "./DeployHelpers.s.sol";
 
 contract DeployScript is ScaffoldETHDeploy {
@@ -16,8 +17,12 @@ contract DeployScript is ScaffoldETHDeploy {
     }
     vm.startBroadcast(deployerPrivateKey);
 
-    // Deploy Spotlight first
-    Spotlight spotlight = new Spotlight(vm.addr(deployerPrivateKey));
+    // Deploy RTP first
+    Reputation rtp = new Reputation();
+    console.logString(string.concat("Reputation deployed at: ", vm.toString(address(rtp))));
+
+    // and then Spotlight
+    Spotlight spotlight = new Spotlight(vm.addr(deployerPrivateKey), address(rtp));
     console.logString(string.concat("Spotlight deployed at: ", vm.toString(address(spotlight))));
 
     // Store deployments for export

--- a/packages/foundry/test/Posts.t.sol
+++ b/packages/foundry/test/Posts.t.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 
 import "../contracts/Spotlight.sol";
+import "../contracts/Reputation.sol";
 import "../contracts/Events.sol";
 import "../contracts/PostLib.sol";
 import "../contracts/SpotlightErrors.sol";
@@ -83,7 +84,8 @@ contract PostManagementTest is Test {
   Vm.Wallet public wallet;
 
   function setUp() public {
-    spotlight = new Spotlight(vm.addr(1));
+    Reputation rpt = new Reputation();
+    spotlight = new Spotlight(vm.addr(1), address(rpt));
     wallet = vm.createWallet(1);
   }
 

--- a/packages/foundry/test/Reputation.t.sol
+++ b/packages/foundry/test/Reputation.t.sol
@@ -20,7 +20,8 @@ contract ReputationTest is Test {
     user2 = address(3);
 
     // Deploy contract
-    reputation = new Reputation(spotlight);
+    reputation = new Reputation();
+    reputation.setSpotlightContract(spotlight);
 
     // Label addresses for better trace output
     vm.label(spotlight, "Spotlight");
@@ -30,8 +31,9 @@ contract ReputationTest is Test {
 
   function testConstructor() public {
     // Test constructor requirements
+    Reputation _rpt = new Reputation();
     vm.expectRevert(SpotlightErrors.SpotlightAddressCannotBeZero.selector);
-    new Reputation(address(0));
+    _rpt.setSpotlightContract(address(0));
 
     // Test spotlight address is set correctly
     assertEq(reputation.spotlightContract(), spotlight);

--- a/packages/foundry/test/Spotlight.t.sol
+++ b/packages/foundry/test/Spotlight.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 import "../contracts/Spotlight.sol";
+import "../contracts/Reputation.sol";
 import "../contracts/Events.sol";
 import "../contracts/SpotlightErrors.sol";
 
@@ -10,7 +11,8 @@ contract SpotlightTest is Test {
   Spotlight public spotlight;
 
   function setUp() public {
-    spotlight = new Spotlight(vm.addr(1));
+    Reputation rpt = new Reputation();
+    spotlight = new Spotlight(vm.addr(1), address(rpt));
   }
 
   function testDeploymentState() public view {

--- a/packages/foundry/test/Votes.t.sol
+++ b/packages/foundry/test/Votes.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 import "../contracts/Spotlight.sol";
+import "../contracts/Reputation.sol";
 import "../contracts/Events.sol";
 import "../contracts/PostLib.sol";
 import "../contracts/SpotlightErrors.sol";
@@ -14,7 +15,8 @@ contract VotesTest is Test {
   bytes public postSig;
 
   function setUp() public {
-    spotlight = new Spotlight(vm.addr(1));
+    Reputation rpt = new Reputation();
+    spotlight = new Spotlight(vm.addr(1), address(rpt));
     wallet1 = vm.createWallet(1);
     wallet2 = vm.createWallet(2);
 

--- a/packages/nextjs/components/post/PaywallMessage.tsx
+++ b/packages/nextjs/components/post/PaywallMessage.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image";
 import { useAccount } from "wagmi";
+import { useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 import { TPost } from "~~/types/spotlight";
+import { notification } from "~~/utils/scaffold-eth";
 
 const PaywallMessage = ({
   post,
@@ -14,12 +16,37 @@ const PaywallMessage = ({
   purchasedPost: TPost;
 }) => {
   const { address } = useAccount();
+  const { writeContractAsync: writeSpotlightContractAsync } = useScaffoldWriteContract("Spotlight");
+
+  const decline = async () => {
+    try {
+      await writeSpotlightContractAsync({
+        functionName: "declinePurchase",
+        args: [post.id, address],
+      });
+    } catch (e: any) {
+      console.log(e);
+      notification.error("Could not decline purchase!");
+    }
+  };
 
   const showPaywalMsg = () => {
     const unsupportedMsg = `This post is currently paywalled, but you are using a wallet \
       that does not support the required features to engage with our \
       payment procotol.`;
-    const purchasePendingMsg = "You have purchased this post. Please wait for review by it's creator.";
+    const purchasePendingMsg = (
+      <>
+        You have purchased this post. Please wait for review by it&apos;s creator.
+        <br />
+        <div className="grid place-content-center">
+          <div>
+            <button className="btn btn-warning" onClick={decline}>
+              Cancel Purchase
+            </button>
+          </div>
+        </div>
+      </>
+    );
     const purchaseMsg = "Please click the unlock icon to purchase this post from it's creator.";
     const creatorMsg = "Click the unlock button to decrypt your post.";
     const purchasedMsg = (

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -6,14 +6,536 @@ import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 
 const deployedContracts = {
   31337: {
+    Reputation: {
+      address: "0xdc64a140aa3e981100a9beca4e685f962f0cf6c9",
+      abi: [
+        {
+          type: "constructor",
+          inputs: [],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
+          name: "allowance",
+          inputs: [
+            {
+              name: "owner",
+              type: "address",
+              internalType: "address",
+            },
+            {
+              name: "spender",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+          outputs: [
+            {
+              name: "",
+              type: "uint256",
+              internalType: "uint256",
+            },
+          ],
+          stateMutability: "view",
+        },
+        {
+          type: "function",
+          name: "approve",
+          inputs: [
+            {
+              name: "spender",
+              type: "address",
+              internalType: "address",
+            },
+            {
+              name: "value",
+              type: "uint256",
+              internalType: "uint256",
+            },
+          ],
+          outputs: [
+            {
+              name: "",
+              type: "bool",
+              internalType: "bool",
+            },
+          ],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
+          name: "balanceOf",
+          inputs: [
+            {
+              name: "account",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+          outputs: [
+            {
+              name: "",
+              type: "uint256",
+              internalType: "uint256",
+            },
+          ],
+          stateMutability: "view",
+        },
+        {
+          type: "function",
+          name: "decimals",
+          inputs: [],
+          outputs: [
+            {
+              name: "",
+              type: "uint8",
+              internalType: "uint8",
+            },
+          ],
+          stateMutability: "view",
+        },
+        {
+          type: "function",
+          name: "downvoteComment",
+          inputs: [
+            {
+              name: "account",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+          outputs: [],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
+          name: "downvotePost",
+          inputs: [
+            {
+              name: "account",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+          outputs: [],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
+          name: "engagementReward",
+          inputs: [
+            {
+              name: "receiver",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+          outputs: [],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
+          name: "name",
+          inputs: [],
+          outputs: [
+            {
+              name: "",
+              type: "string",
+              internalType: "string",
+            },
+          ],
+          stateMutability: "view",
+        },
+        {
+          type: "function",
+          name: "revertDownvotePost",
+          inputs: [
+            {
+              name: "account",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+          outputs: [],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
+          name: "revertUpvotePost",
+          inputs: [
+            {
+              name: "receiver",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+          outputs: [],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
+          name: "setPostsContract",
+          inputs: [
+            {
+              name: "_addr",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+          outputs: [],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
+          name: "setSpotlightContract",
+          inputs: [
+            {
+              name: "_addr",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+          outputs: [],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
+          name: "spotlightContract",
+          inputs: [],
+          outputs: [
+            {
+              name: "",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+          stateMutability: "view",
+        },
+        {
+          type: "function",
+          name: "symbol",
+          inputs: [],
+          outputs: [
+            {
+              name: "",
+              type: "string",
+              internalType: "string",
+            },
+          ],
+          stateMutability: "view",
+        },
+        {
+          type: "function",
+          name: "totalSupply",
+          inputs: [],
+          outputs: [
+            {
+              name: "",
+              type: "uint256",
+              internalType: "uint256",
+            },
+          ],
+          stateMutability: "view",
+        },
+        {
+          type: "function",
+          name: "transfer",
+          inputs: [
+            {
+              name: "to",
+              type: "address",
+              internalType: "address",
+            },
+            {
+              name: "value",
+              type: "uint256",
+              internalType: "uint256",
+            },
+          ],
+          outputs: [
+            {
+              name: "",
+              type: "bool",
+              internalType: "bool",
+            },
+          ],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
+          name: "transferFrom",
+          inputs: [
+            {
+              name: "from",
+              type: "address",
+              internalType: "address",
+            },
+            {
+              name: "to",
+              type: "address",
+              internalType: "address",
+            },
+            {
+              name: "value",
+              type: "uint256",
+              internalType: "uint256",
+            },
+          ],
+          outputs: [
+            {
+              name: "",
+              type: "bool",
+              internalType: "bool",
+            },
+          ],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
+          name: "upvoteComment",
+          inputs: [
+            {
+              name: "receiver",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+          outputs: [],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
+          name: "upvotePost",
+          inputs: [
+            {
+              name: "receiver",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+          outputs: [],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "event",
+          name: "Approval",
+          inputs: [
+            {
+              name: "owner",
+              type: "address",
+              indexed: true,
+              internalType: "address",
+            },
+            {
+              name: "spender",
+              type: "address",
+              indexed: true,
+              internalType: "address",
+            },
+            {
+              name: "value",
+              type: "uint256",
+              indexed: false,
+              internalType: "uint256",
+            },
+          ],
+          anonymous: false,
+        },
+        {
+          type: "event",
+          name: "TokenBurned",
+          inputs: [
+            {
+              name: "account",
+              type: "address",
+              indexed: true,
+              internalType: "address",
+            },
+            {
+              name: "amount",
+              type: "uint256",
+              indexed: false,
+              internalType: "uint256",
+            },
+          ],
+          anonymous: false,
+        },
+        {
+          type: "event",
+          name: "TokenIssued",
+          inputs: [
+            {
+              name: "receiver",
+              type: "address",
+              indexed: true,
+              internalType: "address",
+            },
+            {
+              name: "amount",
+              type: "uint256",
+              indexed: false,
+              internalType: "uint256",
+            },
+          ],
+          anonymous: false,
+        },
+        {
+          type: "event",
+          name: "Transfer",
+          inputs: [
+            {
+              name: "from",
+              type: "address",
+              indexed: true,
+              internalType: "address",
+            },
+            {
+              name: "to",
+              type: "address",
+              indexed: true,
+              internalType: "address",
+            },
+            {
+              name: "value",
+              type: "uint256",
+              indexed: false,
+              internalType: "uint256",
+            },
+          ],
+          anonymous: false,
+        },
+        {
+          type: "error",
+          name: "CannotIssueToZeroAddress",
+          inputs: [],
+        },
+        {
+          type: "error",
+          name: "ERC20InsufficientAllowance",
+          inputs: [
+            {
+              name: "spender",
+              type: "address",
+              internalType: "address",
+            },
+            {
+              name: "allowance",
+              type: "uint256",
+              internalType: "uint256",
+            },
+            {
+              name: "needed",
+              type: "uint256",
+              internalType: "uint256",
+            },
+          ],
+        },
+        {
+          type: "error",
+          name: "ERC20InsufficientBalance",
+          inputs: [
+            {
+              name: "sender",
+              type: "address",
+              internalType: "address",
+            },
+            {
+              name: "balance",
+              type: "uint256",
+              internalType: "uint256",
+            },
+            {
+              name: "needed",
+              type: "uint256",
+              internalType: "uint256",
+            },
+          ],
+        },
+        {
+          type: "error",
+          name: "ERC20InvalidApprover",
+          inputs: [
+            {
+              name: "approver",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+        },
+        {
+          type: "error",
+          name: "ERC20InvalidReceiver",
+          inputs: [
+            {
+              name: "receiver",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+        },
+        {
+          type: "error",
+          name: "ERC20InvalidSender",
+          inputs: [
+            {
+              name: "sender",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+        },
+        {
+          type: "error",
+          name: "ERC20InvalidSpender",
+          inputs: [
+            {
+              name: "spender",
+              type: "address",
+              internalType: "address",
+            },
+          ],
+        },
+        {
+          type: "error",
+          name: "OnlySpotlightContractCanBurnTokens",
+          inputs: [],
+        },
+        {
+          type: "error",
+          name: "OnlySpotlightContractCanIssueTokens",
+          inputs: [],
+        },
+        {
+          type: "error",
+          name: "SpotlightAddressCannotBeZero",
+          inputs: [],
+        },
+      ],
+      inheritedFunctions: {
+        allowance: "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol",
+        approve: "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol",
+        balanceOf: "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol",
+        decimals: "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol",
+        name: "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol",
+        symbol: "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol",
+        totalSupply: "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol",
+        transfer: "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol",
+        transferFrom: "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol",
+      },
+    },
     Spotlight: {
-      address: "0x5fbdb2315678afecb367f032d93f642f64180aa3",
+      address: "0x5fc8d32690cc91d4c39d9d3abcbd16989f875707",
       abi: [
         {
           type: "constructor",
           inputs: [
             {
               name: "_owner",
+              type: "address",
+              internalType: "address",
+            },
+            {
+              name: "_rtpContract",
               type: "address",
               internalType: "address",
             },
@@ -937,19 +1459,6 @@ const deployedContracts = {
               type: "string",
               indexed: false,
               internalType: "string",
-            },
-          ],
-          anonymous: false,
-        },
-        {
-          type: "event",
-          name: "RPTContractCreated",
-          inputs: [
-            {
-              name: "rptAddress",
-              type: "address",
-              indexed: true,
-              internalType: "address",
             },
           ],
           anonymous: false,
@@ -1120,6 +1629,11 @@ const deployedContracts = {
               type: "address",
               internalType: "address",
             },
+            {
+              name: "_rtpContract",
+              type: "address",
+              internalType: "address",
+            },
           ],
           stateMutability: "nonpayable",
         },
@@ -2040,19 +2554,6 @@ const deployedContracts = {
               type: "string",
               indexed: false,
               internalType: "string",
-            },
-          ],
-          anonymous: false,
-        },
-        {
-          type: "event",
-          name: "RPTContractCreated",
-          inputs: [
-            {
-              name: "rptAddress",
-              type: "address",
-              indexed: true,
-              internalType: "address",
             },
           ],
           anonymous: false,

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -7,7 +7,7 @@ import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 const deployedContracts = {
   31337: {
     Spotlight: {
-      address: "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0",
+      address: "0x5fbdb2315678afecb367f032d93f642f64180aa3",
       abi: [
         {
           type: "constructor",
@@ -942,6 +942,19 @@ const deployedContracts = {
           anonymous: false,
         },
         {
+          type: "event",
+          name: "RPTContractCreated",
+          inputs: [
+            {
+              name: "rptAddress",
+              type: "address",
+              indexed: true,
+              internalType: "address",
+            },
+          ],
+          anonymous: false,
+        },
+        {
           type: "error",
           name: "AddressNotRegistered",
           inputs: [],
@@ -1003,12 +1016,12 @@ const deployedContracts = {
         },
         {
           type: "error",
-          name: "OnlyCreatorCanDeclinePurchase",
+          name: "OnlyCreatorCanEdit",
           inputs: [],
         },
         {
           type: "error",
-          name: "OnlyCreatorCanEdit",
+          name: "OnlyCreatorOrPurchaserCanDeclinePurchase",
           inputs: [],
         },
         {
@@ -2032,6 +2045,19 @@ const deployedContracts = {
           anonymous: false,
         },
         {
+          type: "event",
+          name: "RPTContractCreated",
+          inputs: [
+            {
+              name: "rptAddress",
+              type: "address",
+              indexed: true,
+              internalType: "address",
+            },
+          ],
+          anonymous: false,
+        },
+        {
           type: "error",
           name: "AddressNotRegistered",
           inputs: [],
@@ -2093,12 +2119,12 @@ const deployedContracts = {
         },
         {
           type: "error",
-          name: "OnlyCreatorCanDeclinePurchase",
+          name: "OnlyCreatorCanEdit",
           inputs: [],
         },
         {
           type: "error",
-          name: "OnlyCreatorCanEdit",
+          name: "OnlyCreatorOrPurchaserCanDeclinePurchase",
           inputs: [],
         },
         {


### PR DESCRIPTION
Extras:
* Deploy RPT so it's visible in Block Explorer. Instead of emitting an event that has the ERC-20 token contract address buried in it, just deploy the contract so we get the visibility and also the goodies in explorer of "total supply" etc